### PR TITLE
Arallsopp update switch

### DIFF
--- a/custom_components/tesla_custom/const.py
+++ b/custom_components/tesla_custom/const.py
@@ -25,7 +25,7 @@ ICONS = {
     "parking brake sensor": "mdi:car-brake-parking",
     "charger sensor": "mdi:ev-station",
     "charger switch": "mdi:battery-charging",
-    "update switch": "mdi:update",
+    "update switch": "mdi:car-connected",
     "maxrange switch": "mdi:gauge-full",
     "temperature sensor": "mdi:thermometer",
     "location tracker": "mdi:crosshairs-gps",

--- a/custom_components/tesla_custom/strings.json
+++ b/custom_components/tesla_custom/strings.json
@@ -21,7 +21,7 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "Seconds between scans",
+          "scan_interval": "Seconds between polling",
           "enable_wake_on_start": "Force cars awake on startup"
         }
       }

--- a/custom_components/tesla_custom/switch.py
+++ b/custom_components/tesla_custom/switch.py
@@ -75,7 +75,7 @@ class RangeSwitch(TeslaDevice, SwitchEntity):
 
 
 class UpdateSwitch(TeslaDevice, SwitchEntity):
-    """Representation of a Tesla update switch."""
+    """Representation of a Tesla update switch. Described in UI as polling """
 
     def __init__(self, tesla_device, coordinator):
         """Initialise the switch."""
@@ -85,7 +85,7 @@ class UpdateSwitch(TeslaDevice, SwitchEntity):
     @property
     def name(self):
         """Return the name of the device."""
-        return super().name.replace("charger", "update")
+        return super().name.replace("charger", "polling")
 
     @property
     def unique_id(self) -> str:
@@ -94,13 +94,13 @@ class UpdateSwitch(TeslaDevice, SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         """Send the on command."""
-        _LOGGER.debug("Enable updates: %s %s", self.name, self.tesla_device.id())
+        _LOGGER.debug("Enable polling: %s %s", self.name, self.tesla_device.id())
         self.controller.set_updates(self.tesla_device.id(), True)
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Send the off command."""
-        _LOGGER.debug("Disable updates: %s %s", self.name, self.tesla_device.id())
+        _LOGGER.debug("Disable polling: %s %s", self.name, self.tesla_device.id())
         self.controller.set_updates(self.tesla_device.id(), False)
         self.async_write_ha_state()
 

--- a/custom_components/tesla_custom/translations/en.json
+++ b/custom_components/tesla_custom/translations/en.json
@@ -21,7 +21,7 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "Seconds between scans",
+          "scan_interval": "Seconds between polling",
           "enable_wake_on_start": "Force cars awake on startup"
         }
       }


### PR DESCRIPTION
Relates to Issue #22 

## Straightforward changes:

- the icon for 'update switch' from mdi:update to mdi:car-connected.
- the text 'seconds between scans' to 'seconds between polling'.

## More complicated:
I think I've also changed the name and ID of the update switch so that it appears as 'polling switch' in the UI and logs. I'm wondering if that's actually a breaking change, as potentially people have automations or scripts that might target the update switch entity. 
