### PR TITLE
Add a note in the docs about how to turn on climate via a scene

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This integration provides the following platforms:
 - Sensors - such as Battery level, Inside/Outside temperature, odometer, estimated range, and charging rate.
 - Device tracker - to track location of your car
 - Locks - Door lock, rear trunk lock, front trunk (frunk) lock and charger door lock. Enables you to control Tesla's door, trunks and charger door lock.
-- Climate - HVAC control. Allow you to control (turn on/off, set target temperature) your Tesla's HVAC system. Also enables preset modes to enable or disable max defrost mode `defrost` or `normal` operation mode.
+- Climate - HVAC control. Allow you to control (turn on/off, set target temperature) your Tesla's HVAC system. Also enables preset modes to enable or disable max defrost mode `defrost` or `normal` operation mode. **NOTE:** Set `state` to `heat_cool` or `off` to enable/disable your Tesla's climate system via a scene.
 - Switches - Charger and max range switch allow you to start/stop charging and set max range charging. Polling switch allows you to disable polling of vehicles to conserve battery. Sentry mode switch enables or disable Sentry mode.
 - Buttons - Horn and Flash lights
 


### PR DESCRIPTION
I had a heck of a time running down how to turn on my Tesla's climate via a scene; looks like [I'm not alone](https://community.home-assistant.io/t/help-with-climate-automation-tesla/39644). Here's the scene that finally worked for me:

```yaml
- name: I'm Getting Ready to Leave
  icon: "mdi:car"
  entities:
    climate.tesla_model_y_hvac_climate_system:
      state: heat_cool
```

Based on the docs I was expecting to need to set `state` to `on` and `hvac_mode` to `heat_cool`.