### PR TITLE
Disable forced updates for device trackers

### DIFF
--- a/custom_components/tesla_custom/device_tracker.py
+++ b/custom_components/tesla_custom/device_tracker.py
@@ -26,6 +26,11 @@ class TeslaDeviceEntity(TeslaDevice, TrackerEntity):
     """A class representing a Tesla device."""
 
     @property
+    def force_update(self):
+        """Disable forced updated since we are polling via the coordinator updates."""
+        return False
+
+    @property
     def latitude(self) -> float | None:
         """Return latitude value of the device."""
         location = self.tesla_device.get_location()


### PR DESCRIPTION
Forced updates are only needed if we are [not polling](https://github.com/home-assistant/core/blob/dev/homeassistant/components/device_tracker/config_entry.py#L204). Since the coordinator
is effectively doing the polling instead of Home Assistant internals doing it
via should_poll set to True, we need to set the property manually to avoid
writing a state update every time the coordinator callback happens to avoid
a state changed event when nothing has really changed.