### PR TITLE
feat: add trigger homelink button (disabled by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This integration provides the following platforms:
 - Locks - Door lock, rear trunk lock, front trunk (frunk) lock and charger door lock. Enables you to control Tesla's door, trunks and charger door lock.
 - Climate - HVAC control. Allow you to control (turn on/off, set target temperature) your Tesla's HVAC system. Also enables preset modes to enable or disable max defrost mode `defrost` or `normal` operation mode. **NOTE:** Set `state` to `heat_cool` or `off` to enable/disable your Tesla's climate system via a scene.
 - Switches - Charger and max range switch allow you to start/stop charging and set max range charging. Polling switch allows you to disable polling of vehicles to conserve battery. Sentry mode switch enables or disable Sentry mode.
-- Buttons - Horn and Flash lights
+- Buttons - Horn, Flash lights, and Trigger homelink. **Note:** The homelink button is disabled by default as many vehicles don't have the homelink option. Enable via configuration/entities if desired.
 
 The following sensors provide all available vehicle data as attributes. These sensors are disabled by default and need to be enabled in HASS first. It is also recommended to exclude these sensors from [recorder](https://www.home-assistant.io/integrations/recorder/).
 

--- a/custom_components/tesla_custom/button.py
+++ b/custom_components/tesla_custom/button.py
@@ -66,7 +66,7 @@ class TriggerHomelink(TeslaDevice, ButtonEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self.tesla_device.available()
+        return super().available and self.tesla_device.available()
 
     @TeslaDevice.Decorators.check_for_reauth
     async def async_press(self, **kwargs):

--- a/custom_components/tesla_custom/button.py
+++ b/custom_components/tesla_custom/button.py
@@ -5,6 +5,7 @@ import logging
 _LOGGER = logging.getLogger(__name__)
 
 from homeassistant.components.button import ButtonEntity
+from teslajsonpy.exceptions import HomelinkError
 
 from . import DOMAIN as TESLA_DOMAIN
 from .tesla_device import TeslaDevice
@@ -19,6 +20,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             entities.append(Horn(device, coordinator))
         elif device.type == "flash lights":
             entities.append(FlashLights(device, coordinator))
+        elif device.type == "trigger homelink":
+            entities.append(TriggerHomelink(device, coordinator))
     async_add_entities(entities, True)
 
 
@@ -50,3 +53,26 @@ class FlashLights(TeslaDevice, ButtonEntity):
         """Send the command."""
         _LOGGER.debug("Flash lights: %s", self.name)
         await self.tesla_device.flash_lights()
+
+
+class TriggerHomelink(TeslaDevice, ButtonEntity):
+    """Representation of a Tesla Homelink button."""
+
+    def __init__(self, tesla_device, coordinator):
+        """Initialise the button."""
+        super().__init__(tesla_device, coordinator)
+        self.controller = coordinator.controller
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.tesla_device.available()
+
+    @TeslaDevice.Decorators.check_for_reauth
+    async def async_press(self, **kwargs):
+        """Send the command."""
+        _LOGGER.debug("Trigger homelink: %s", self.name)
+        try:
+            await self.tesla_device.trigger_homelink()
+        except HomelinkError as ex:
+            _LOGGER.error("%s", ex.message)

--- a/custom_components/tesla_custom/const.py
+++ b/custom_components/tesla_custom/const.py
@@ -35,6 +35,7 @@ ICONS = {
     "sentry mode switch": "mdi:shield-car",
     "horn": "mdi:bullhorn",
     "flash lights": "mdi:car-light-high",
+    "trigger homelink": "mdi:garage",
     "solar panel": "mdi:solar-panel",
 }
 AUTH_CALLBACK_PATH = "/auth/tesla/callback"


### PR DESCRIPTION
This PR adds a 'trigger homelink" button to the Tesla integration, which is disabled by default.

It works by taking the current location of the vehicle to feed into the required lat/lon params for the API call, which would normally be the user phone's location when called by the official Tesla app. For users this means it's possible to remotely open/close the homelink device (please always monitor surroundings for safety).

The button will be disabled by default in HA, and would need to manually be enabled by the the user if they wish to utilize it.

If enabled, it would still show as unavailable in these cases:

- if the vehicle does not have the homelink option purchased/installed.
- if the vehicle has no homelink devices programmed.
- if the vehicle is unreachable (as is normal behavior for all entities)

It will, however, show available in all other cases, even if the vehicle is reportedly too far from the homelink device. This is to ensure long polling times wouldn't prevent users from using the button shortly after driving within range of the homelink device.
Pressing the button while the vehicle is actually out of range of the homelink device would result in an error logged in HA (along with any other errors the API request might return).

Tested by:

- creating and running unit tests in teslajsonpy
- running a dev instance of HA with a homelink-equipped Tesla:
  - tested error logging of expected errors (too far from device, etc.)
  - tested real-world ability to open/close a programmed homelink device
  - tested button availability when vehicle is offline, or no homelink devices added.