### PR TITLE
Add Heated Seats support via the Select entity

### DIFF
--- a/custom_components/tesla_custom/const.py
+++ b/custom_components/tesla_custom/const.py
@@ -18,6 +18,7 @@ PLATFORMS = [
     "device_tracker",
     "switch",
     "button",
+    "select",
 ]
 
 ICONS = {

--- a/custom_components/tesla_custom/select.py
+++ b/custom_components/tesla_custom/select.py
@@ -1,0 +1,52 @@
+"""Support for Tesla selects."""
+import logging
+
+from homeassistant.components.select import SelectEntity
+
+from . import DOMAIN as TESLA_DOMAIN
+from .tesla_device import TeslaDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+OPTIONS = [
+    "Off",
+    "Low",
+    "Medium",
+    "High",
+]
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Tesla selects by config_entry."""
+    coordinator = hass.data[TESLA_DOMAIN][config_entry.entry_id]["coordinator"]
+    entities = []
+    for device in hass.data[TESLA_DOMAIN][config_entry.entry_id]["devices"]["select"]:
+        if device.type.startswith("heated seat "):
+            entities.append(HeatedSeatSelect(device, coordinator))
+    async_add_entities(entities, True)
+
+
+class HeatedSeatSelect(TeslaDevice, SelectEntity):
+    """Representation of a Tesla Heated Seat Select."""
+
+    async def async_select_option(self, option: str, **kwargs):
+        """Change the selected option."""
+        level: int = OPTIONS.index(option)
+
+        _LOGGER.debug("Setting %s to %s", self.name, level)
+        await self.tesla_device.set_seat_heat_level(level)
+        self.async_write_ha_state()
+
+    @property
+    def current_option(self):
+        """Return the selected entity option to represent the entity state."""
+        current_value = self.tesla_device.get_seat_heat_level()
+
+        if current_value is None:
+            return None
+        return OPTIONS[current_value]
+
+    @property
+    def options(self):
+        """Return a set of selectable options."""
+        return OPTIONS

--- a/custom_components/tesla_custom/select.py
+++ b/custom_components/tesla_custom/select.py
@@ -43,7 +43,7 @@ class HeatedSeatSelect(TeslaDevice, SelectEntity):
         current_value = self.tesla_device.get_seat_heat_level()
 
         if current_value is None:
-            return None
+            return OPTIONS[0]
         return OPTIONS[current_value]
 
     @property


### PR DESCRIPTION
# Add Heated Seats support via the Select entity

Limitations:
1. The Heated Seat data relies on the Climate Data from Tesla. This only returns a value while the climate is on. This means that the select entities will stay in their previous state until the climate is turned on in the car. The selects update as expected while Climate is turned on.
2. Heated Seats will only change while climate is enabled. This means that if you want to turn on a heated seat, you need to first turn on the climate control, then change the select to the desired level. This is a limitation of the Tesla API.

I thought about automating turning on the climate if the user sets an option and climate isn't on, but automatically turning on the climate could have unintended consequences. 