### PR TITLE
Add support for async_remove_config_entry_device

### DIFF
--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -293,7 +293,7 @@ class TeslaDataUpdateCoordinator(DataUpdateCoordinator):
 async def async_remove_config_entry_device(
     hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
 ) -> bool:
-    """Remove homekit_controller config entry from a device."""
+    """Remove tesla_custom config entry from a device."""
     controller: TeslaAPI = hass.data[DOMAIN][config_entry.entry_id][
         "coordinator"
     ].controller

--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -6,7 +6,7 @@ from http import HTTPStatus
 import logging
 
 import async_timeout
-from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
     CONF_DOMAIN,
@@ -15,8 +15,9 @@ from homeassistant.const import (
     CONF_USERNAME,
     EVENT_HOMEASSISTANT_CLOSE,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.httpx_client import SERVER_SOFTWARE, USER_AGENT
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 import httpx
@@ -38,6 +39,7 @@ from .const import (
     PLATFORMS,
 )
 from .services import async_setup_services, async_unload_services
+from .tesla_device import device_identifier
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -286,3 +288,16 @@ class TeslaDataUpdateCoordinator(DataUpdateCoordinator):
             await self.hass.config_entries.async_reload(self.config_entry.entry_id)
         except TeslaException as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Remove homekit_controller config entry from a device."""
+    controller: TeslaAPI = hass.data[DOMAIN][config_entry.entry_id][
+        "coordinator"
+    ].controller
+    return not device_entry.identifiers.intersection(
+        device_identifier(telsa_device)
+        for telsa_device in controller.get_homeassistant_components()
+    )

--- a/custom_components/tesla_custom/tesla_device.py
+++ b/custom_components/tesla_custom/tesla_device.py
@@ -17,6 +17,9 @@ _LOGGER = logging.getLogger(__name__)
 
 def device_identifier(tesla_device) -> Tuple[str, int]:
     """Return the identifier for a tesla device."""
+    # Note that Home Assistant types this to be
+    # tuple[str, str] but since that would involve
+    # migrating, it is not changed here.
     return (DOMAIN, tesla_device.id())
 
 

--- a/custom_components/tesla_custom/tesla_device.py
+++ b/custom_components/tesla_custom/tesla_device.py
@@ -97,7 +97,7 @@ class TeslaDevice(CoordinatorEntity):
         """Return the device_info of the device."""
         if hasattr(self.tesla_device, "car_name"):
             return {
-                "identifiers": {device_identifier(tesla_device)},
+                "identifiers": {device_identifier(self.tesla_device)},
                 "name": self.tesla_device.car_name(),
                 "manufacturer": "Tesla",
                 "model": self.tesla_device.car_type,
@@ -105,7 +105,7 @@ class TeslaDevice(CoordinatorEntity):
             }
         elif hasattr(self.tesla_device, "site_name"):
             return {
-                "identifiers": {device_identifier(tesla_device)},
+                "identifiers": {device_identifier(self.tesla_device)},
                 "name": self.tesla_device.site_name(),
                 "manufacturer": "Tesla",
             }

--- a/custom_components/tesla_custom/tesla_device.py
+++ b/custom_components/tesla_custom/tesla_device.py
@@ -1,7 +1,7 @@
 """Support for Tesla cars."""
 from functools import wraps
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 
 from homeassistant.const import ATTR_BATTERY_CHARGING, ATTR_BATTERY_LEVEL
 from homeassistant.core import callback
@@ -13,6 +13,11 @@ from teslajsonpy.exceptions import IncompleteCredentials
 from .const import DOMAIN, ICONS
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def device_identifier(tesla_device) -> Tuple[str, int]:
+    """Return the identifier for a tesla device."""
+    return (DOMAIN, tesla_device.id())
 
 
 class TeslaDevice(CoordinatorEntity):
@@ -92,7 +97,7 @@ class TeslaDevice(CoordinatorEntity):
         """Return the device_info of the device."""
         if hasattr(self.tesla_device, "car_name"):
             return {
-                "identifiers": {(DOMAIN, self.tesla_device.id())},
+                "identifiers": {device_identifier(tesla_device)},
                 "name": self.tesla_device.car_name(),
                 "manufacturer": "Tesla",
                 "model": self.tesla_device.car_type,
@@ -100,7 +105,7 @@ class TeslaDevice(CoordinatorEntity):
             }
         elif hasattr(self.tesla_device, "site_name"):
             return {
-                "identifiers": {(DOMAIN, self.tesla_device.id())},
+                "identifiers": {device_identifier(tesla_device)},
                 "name": self.tesla_device.site_name(),
                 "manufacturer": "Tesla",
             }


### PR DESCRIPTION
Enables the Delete device button on the devices page

I had duplicate devices since at some point the identifiers had changed

<img width="1030" alt="Screen_Shot_2022-05-28_at_11_22_05" src="https://user-images.githubusercontent.com/663432/170843266-ff466377-c09c-4929-b544-adf39cf68156.png">

