### PR TITLE
Bump teslajsonpy to 2.4.4

### DIFF
--- a/custom_components/tesla_custom/manifest.json
+++ b/custom_components/tesla_custom/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/alandtse/tesla/wiki",
   "issue_tracker": "https://github.com/alandtse/tesla/issues",
-  "requirements": ["teslajsonpy==2.4.3"],
+  "requirements": ["teslajsonpy==2.4.4"],
   "codeowners": ["@alandtse"],
   "dependencies": ["http"],
   "dhcp": [


### PR DESCRIPTION
Fixes issue where some energy sites only report `grid_status` when it's `Unknown`.

Fixes #257.

Requires [this teslajsonpy pull request](https://github.com/zabuldon/teslajsonpy/pull/346) to be merged and published first.