### PR TITLE
fix: set sensor device class

### DIFF
--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -16,7 +16,6 @@ from homeassistant.const import (
     PERCENTAGE,
     POWER_WATT,
     POWER_KILO_WATT,
-    SPEED_KILOMETERS_PER_HOUR,
     SPEED_MILES_PER_HOUR,
     TEMP_CELSIUS,
 )
@@ -203,7 +202,9 @@ class TeslaCarChargerRate(TeslaCarEntity, SensorEntity):
         """Initialize charging rate entity."""
         super().__init__(hass, car, coordinator)
         self.type = "charging rate"
+        self._attr_device_class = SensorDeviceClass.SPEED
         self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_native_unit_of_measurement = SPEED_MILES_PER_HOUR
         self._attr_icon = "mdi:speedometer"
 
     @property
@@ -214,20 +215,7 @@ class TeslaCarChargerRate(TeslaCarEntity, SensorEntity):
         if charge_rate is None:
             return charge_rate
 
-        if self._car.gui_distance_units == DISTANCE_UNITS_KM_HR:
-            charge_rate = DistanceConverter.convert(
-                charge_rate, LENGTH_MILES, LENGTH_KILOMETERS
-            )
-
         return round(charge_rate, 2)
-
-    @property
-    def native_unit_of_measurement(self) -> str:
-        """Return distance units."""
-        if self._car.gui_distance_units == DISTANCE_UNITS_KM_HR:
-            return SPEED_KILOMETERS_PER_HOUR
-
-        return SPEED_MILES_PER_HOUR
 
     @property
     def extra_state_attributes(self):
@@ -249,8 +237,9 @@ class TeslaCarOdometer(TeslaCarEntity, SensorEntity):
         """Initialize odometer entity."""
         super().__init__(hass, car, coordinator)
         self.type = "odometer"
-        self._attr_device_class = None
+        self._attr_device_class = SensorDeviceClass.DISTANCE
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+        self._attr_native_unit_of_measurement = LENGTH_MILES
         self._attr_icon = "mdi:counter"
 
     @property
@@ -261,20 +250,7 @@ class TeslaCarOdometer(TeslaCarEntity, SensorEntity):
         if odometer_value is None:
             return None
 
-        if self._car.gui_distance_units == DISTANCE_UNITS_KM_HR:
-            odometer_value = DistanceConverter.convert(
-                odometer_value, LENGTH_MILES, LENGTH_KILOMETERS
-            )
-
         return round(odometer_value, 2)
-
-    @property
-    def native_unit_of_measurement(self) -> str:
-        """Return distance units."""
-        if self._car.gui_distance_units == DISTANCE_UNITS_KM_HR:
-            return LENGTH_KILOMETERS
-
-        return LENGTH_MILES
 
 
 class TeslaCarRange(TeslaCarEntity, SensorEntity):
@@ -289,8 +265,9 @@ class TeslaCarRange(TeslaCarEntity, SensorEntity):
         """Initialize range entity."""
         super().__init__(hass, car, coordinator)
         self.type = "range"
-        self._attr_device_class = None
+        self._attr_device_class = SensorDeviceClass.DISTANCE
         self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_native_unit_of_measurement = LENGTH_MILES
         self._attr_icon = "mdi:gauge"
 
     @property
@@ -304,20 +281,7 @@ class TeslaCarRange(TeslaCarEntity, SensorEntity):
         if range_value is None:
             return None
 
-        if self._car.gui_distance_units == DISTANCE_UNITS_KM_HR:
-            range_value = DistanceConverter.convert(
-                range_value, LENGTH_MILES, LENGTH_KILOMETERS
-            )
-
         return round(range_value, 2)
-
-    @property
-    def native_unit_of_measurement(self) -> str:
-        """Return distance units."""
-        if self._car.gui_distance_units == DISTANCE_UNITS_KM_HR:
-            return LENGTH_KILOMETERS
-
-        return LENGTH_MILES
 
 
 class TeslaCarTemp(TeslaCarEntity, SensorEntity):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -190,6 +190,7 @@ async def test_charger_rate_value(hass: HomeAssistant) -> None:
     state = hass.states.get("sensor.my_model_s_charging_rate")
     assert state.state == str(car_mock_data.VEHICLE_DATA["charge_state"]["charge_rate"])
 
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.SPEED
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
     assert (
@@ -245,6 +246,7 @@ async def test_odometer_value(hass: HomeAssistant) -> None:
         round(car_mock_data.VEHICLE_DATA["vehicle_state"]["odometer"], 1)
     )
 
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.DISTANCE
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL_INCREASING
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == LENGTH_MILES
 
@@ -272,6 +274,7 @@ async def test_range_value(hass: HomeAssistant) -> None:
         car_mock_data.VEHICLE_DATA["charge_state"]["battery_range"]
     )
 
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.DISTANCE
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == LENGTH_MILES
 


### PR DESCRIPTION
#### Change

- Specify device class for sensors to allow users to specify the unit of measurement for each entity.

#### Details

- Reverts a [previous PR](https://github.com/alandtse/tesla/pull/288) but this still fixes #284. Specifically, if a UK user has their Home Assistant Unit System set to metric, they can still set the units for the odometer to miles (one example).