### PR TITLE
feat: Add charge port latch lock, #323

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This integration provides the following entities for vehicles:
 - Buttons - horn, flash lights, wake up<sup>1</sup>, force data update<sup>1</sup> and trigger HomeLink. **Note:** The HomeLink button is disabled by default as some vehicles don't have this option. Enable via configuration/entities if desired.
 - Climate - turn HVAC on/off, set target temperature, set preset modes (defrost, keep on, dog mode and camp mode).
 - Device tracker - car location<sup>1</sup>.
-- Locks - door lock, rear trunk lock, front trunk (frunk) lock and charger door lock.
+- Locks - door lock, and charge port latch lock.
 **Note:** Set `state` to `heat_cool` or `off` to enable/disable your Tesla's climate system via a scene.
 - Selects - seat heaters and cabin overheat protection<sup>2</sup>.
 - Sensors - battery level, charge rate, energy added, inside/outside temperature, odometer and estimated range.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This integration provides the following entities for vehicles:
 - Buttons - horn, flash lights, wake up<sup>1</sup>, force data update<sup>1</sup> and trigger HomeLink. **Note:** The HomeLink button is disabled by default as some vehicles don't have this option. Enable via configuration/entities if desired.
 - Climate - turn HVAC on/off, set target temperature, set preset modes (defrost, keep on, dog mode and camp mode).
 - Device tracker - car location<sup>1</sup>.
-- Locks - door lock, and charge port latch lock.
+- Locks - door lock, rear trunk lock, front trunk (frunk) lock and charger door lock.
 **Note:** Set `state` to `heat_cool` or `off` to enable/disable your Tesla's climate system via a scene.
 - Selects - seat heaters and cabin overheat protection<sup>2</sup>.
 - Sensors - battery level, charge rate, energy added, inside/outside temperature, odometer and estimated range.

--- a/custom_components/tesla_custom/lock.py
+++ b/custom_components/tesla_custom/lock.py
@@ -54,3 +54,30 @@ class TeslaCarDoors(TeslaCarEntity, LockEntity):
     def is_locked(self):
         """Return True if door is locked."""
         return self._car.is_locked
+
+
+class TeslaCarChargePortLatch(TeslaCarEntity, LockEntity):
+    """Representation of a Tesla charge port latch."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        car: TeslaCar,
+        coordinator: TeslaDataUpdateCoordinator,
+    ) -> None:
+        """Initialize charge port latch (lock) entity."""
+        super().__init__(hass, car, coordinator)
+        self._attr_icon = "mdi:ev-plug-tesla"
+
+    async def async_unlock(self, **kwargs):
+        """Send unlock command."""
+        _LOGGER.debug("Unlocking: %s", self.name)
+        await self._car.charge_port_door_open()
+        await self.async_update_ha_state()
+
+    @property
+    def is_locked(self):
+        """Return True if charge port latch is engaged."""
+        if self._car.charge_port_latch == "Engaged":
+            return True
+        return False

--- a/custom_components/tesla_custom/lock.py
+++ b/custom_components/tesla_custom/lock.py
@@ -3,7 +3,10 @@ import logging
 
 from teslajsonpy.car import TeslaCar
 
-from homeassistant.components.lock import LockEntity
+from homeassistant.components.lock import (
+    LockEntity,
+    LockEntityFeature,
+)
 from homeassistant.core import HomeAssistant
 
 from . import TeslaDataUpdateCoordinator
@@ -21,6 +24,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
 
     for car in cars.values():
         entities.append(TeslaCarDoors(hass, car, coordinator))
+        entities.append(TeslaCarChargePortLatch(hass, car, coordinator))
 
     async_add_entities(entities, True)
 
@@ -67,13 +71,27 @@ class TeslaCarChargePortLatch(TeslaCarEntity, LockEntity):
     ) -> None:
         """Initialize charge port latch (lock) entity."""
         super().__init__(hass, car, coordinator)
+        self.type = "charge port latch"
         self._attr_icon = "mdi:ev-plug-tesla"
+        self._attr_supported_features = (
+            LockEntityFeature.OPEN
+        )
+
+    async def async_open(self, **kwargs):
+        """Send open command."""
+        _LOGGER.debug("Opening: %s", self.name)
+        await self._car.charge_port_door_open()
+        await self.async_update_ha_state()
 
     async def async_unlock(self, **kwargs):
         """Send unlock command."""
         _LOGGER.debug("Unlocking: %s", self.name)
         await self._car.charge_port_door_open()
         await self.async_update_ha_state()
+
+    async def async_lock(self, **kwargs):
+        """Log lock command not possible."""
+        _LOGGER.debug("Locking charge port latch not possible with Tesla's API.")
 
     @property
     def is_locked(self):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -44,3 +44,17 @@ async def test_car_door(hass: HomeAssistant) -> None:
             blocking=True,
         )
         mock_unlock.assert_awaited_once()
+
+
+async def test_charge_port_latch(hass: HomeAssistant) -> None:
+    """Tests car charge port latch."""
+    await setup_platform(hass, LOCK_DOMAIN)
+
+    with patch("teslajsonpy.car.TeslaCar.charge_port_door_open") as mock_unlock:
+        assert await hass.services.async_call(
+            LOCK_DOMAIN,
+            SERVICE_UNLOCK,
+            {ATTR_ENTITY_ID: "lock.my_model_s_charge_port_latch"},
+            blocking=True,
+        )
+        mock_unlock.assert_awaited_once()


### PR DESCRIPTION
https://github.com/alandtse/tesla/issues/323

Feature working in the dev container. 

There is no option to close the latch with Tesla's API. The car itself handles that. I could not find a way to hid the "lock" feature so I'm having it throw a message in the logs that it cannot be locked. I'm not sure what is best practice in that situation. 