### PR TITLE
fix: charge power sensor from int to float

### DIFF
--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -175,7 +175,7 @@ class TeslaCarChargerPower(TeslaCarEntity, SensorEntity):
         self._attr_native_unit_of_measurement = POWER_KILO_WATT
 
     @property
-    def native_value(self) -> int:
+    def native_value(self) -> float:
         """Return the charger power."""
         return self._car.charger_power
 


### PR DESCRIPTION
I would like the charger power sensor to be a float instead of an integer. I use it to calculate charging costs and the approximation to an integer makes the calculation less precise.