### PR TITLE
feat: add binary_sensor.<car>_asleep

### DIFF
--- a/custom_components/tesla_custom/binary_sensor.py
+++ b/custom_components/tesla_custom/binary_sensor.py
@@ -28,6 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
     for car in cars.values():
         entities.append(TeslaCarParkingBrake(hass, car, coordinator))
         entities.append(TeslaCarOnline(hass, car, coordinator))
+        entities.append(TeslaCarAsleep(hass, car, coordinator))
         entities.append(TeslaCarChargerConnection(hass, car, coordinator))
         entities.append(TeslaCarCharging(hass, car, coordinator))
 
@@ -140,7 +141,28 @@ class TeslaCarOnline(TeslaCarEntity, BinarySensorEntity):
             "vehicle_id": str(self._car.vehicle_id),
             "vin": self._car.vin,
             "id": str(self._car.id),
+            "state": self._car.state,
         }
+
+
+class TeslaCarAsleep(TeslaCarEntity, BinarySensorEntity):
+    """Representation of a Tesla car asleep binary sensor."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        car: TeslaCar,
+        coordinator: TeslaDataUpdateCoordinator,
+    ) -> None:
+        """Initialize car asleep entity."""
+        super().__init__(hass, car, coordinator)
+        self.type = "asleep"
+        self._attr_device_class = None
+
+    @property
+    def is_on(self):
+        """Return True if car is asleep."""
+        return self._car.state == "asleep"
 
 
 class TeslaEnergyBatteryCharging(TeslaEnergyEntity, BinarySensorEntity):

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -105,6 +105,15 @@ async def test_car_online(hass: HomeAssistant) -> None:
     )
     assert state.attributes.get("vin") == car_mock_data.VEHICLE["vin"]
     assert state.attributes.get("id") == str(car_mock_data.VEHICLE["id"])
+    assert state.attributes.get("state") == car_mock_data.VEHICLE["state"]
+
+
+async def test_car_asleep(hass: HomeAssistant) -> None:
+    """Tests car asleep is getting the correct value."""
+    await setup_platform(hass, BINARY_SENSOR_DOMAIN)
+
+    state = hass.states.get("binary_sensor.my_model_s_asleep")
+    assert state.state == "off"
 
 
 async def test_battery_charging(hass: HomeAssistant) -> None:


### PR DESCRIPTION
For #360 

This adds a binary sensor which is `on` if the car is asleep, allowing automations, dashboards, etc to reflect if the car is asleep vs unreachable.

This also adds a `state` attribute to `binary_sensor.<car>_online`, allowing for a bit more insight into the variations of the car's "online-ness"