### PR TITLE
fix: vehicles use usable_battery_level to match app

### DIFF
--- a/custom_components/tesla_custom/manifest.json
+++ b/custom_components/tesla_custom/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://github.com/alandtse/tesla/wiki",
   "issue_tracker": "https://github.com/alandtse/tesla/issues",
   "requirements": [
-    "teslajsonpy==3.1.0"
+    "teslajsonpy==3.2.0"
   ],
   "codeowners": [
     "@alandtse"

--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -99,16 +99,24 @@ class TeslaCarBattery(TeslaCarEntity, SensorEntity):
     @property
     def native_value(self) -> int:
         """Return battery level."""
-        return self._car.battery_level
+        # usable_battery_level matches the Tesla app and car display
+        return self._car.usable_battery_level
 
     @property
     def icon(self):
         """Return icon for the battery."""
-        charging = self._car.battery_level == "Charging"
+        charging = self._car.charging_state == "Charging"
 
         return icon_for_battery_level(
             battery_level=self.native_value, charging=charging
         )
+
+    @property
+    def extra_state_attributes(self):
+        """Return device state attributes."""
+        return {
+            "raw_soc": self._car.battery_level,
+        }
 
 
 class TeslaCarChargerEnergy(TeslaCarEntity, SensorEntity):

--- a/poetry.lock
+++ b/poetry.lock
@@ -1507,7 +1507,7 @@ tests = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "teslajsonpy"
-version = "3.1.0"
+version = "3.2.0"
 description = "A library to work with Tesla API."
 category = "main"
 optional = false
@@ -2923,8 +2923,8 @@ termcolor = [
     {file = "termcolor-2.0.1.tar.gz", hash = "sha256:6b2cf769e93364a2676e1de56a7c0cff2cf5bd07f37e9cc80b0dd6320ebfe388"},
 ]
 teslajsonpy = [
-    {file = "teslajsonpy-3.1.0-py3-none-any.whl", hash = "sha256:343004a24ca5dbd26f2a3e5f9c3dc6b522422600040565575494cbfb9c0a7e75"},
-    {file = "teslajsonpy-3.1.0.tar.gz", hash = "sha256:efd1e43e5ef7d2bae24990c5a8394494722583b5d4af767742bfa3044cb4fc1f"},
+    {file = "teslajsonpy-3.2.0-py3-none-any.whl", hash = "sha256:0e5edc405f5dc603ab22e3dba9e918e0090d5831041f455b37bf470120c528c9"},
+    {file = "teslajsonpy-3.2.0.tar.gz", hash = "sha256:cdb87845c9c875fc752fb96499608f309913259784a00bef33beb2afc664fdcb"},
 ]
 text-unidecode = [
     {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-teslajsonpy = "^3.1.0"
+teslajsonpy = "^3.2.0"
 
 [tool.poetry.dev-dependencies]
 homeassistant = ">=2021.10.0"

--- a/tests/mock_data/car.py
+++ b/tests/mock_data/car.py
@@ -83,7 +83,7 @@ VEHICLE_DATA = {
         "time_to_full_charge": 0.25,
         "timestamp": 1661641175268,
         "trip_charging": False,
-        "usable_battery_level": 78,
+        "usable_battery_level": 77,
         "user_charge_enable_request": None,
     },
     "climate_state": {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -132,12 +132,16 @@ async def test_battery_value(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.my_model_s_battery")
     assert state.state == str(
-        car_mock_data.VEHICLE_DATA["charge_state"]["battery_level"]
+        car_mock_data.VEHICLE_DATA["charge_state"]["usable_battery_level"]
     )
 
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.BATTERY
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
+    assert (
+        state.attributes.get("raw_soc")
+        == car_mock_data.VEHICLE_DATA["charge_state"]["battery_level"]
+    )
 
 
 async def test_charger_energy_value(hass: HomeAssistant) -> None:


### PR DESCRIPTION
For #359 

This updates the battery sensor for vehicles to use the `usable_battery_level` value so that it matches the Tesla app and in-car display in all weather conditions.

Additionally a `raw_soc` attribute is added to the battery sensor to provide insight into the battery's SOC, which does not change with temperature. This allows for users to detect reduced range due to cold (such as the snowflake icon in the app) if they wish to do so.

Lastly this PR fixes a bug in that the battery icon did not reflect Charging status due to a typo that I happened to notice while doing the above.