### PR TITLE
fix: update car-asleep binary sensor icon

### DIFF
--- a/custom_components/tesla_custom/binary_sensor.py
+++ b/custom_components/tesla_custom/binary_sensor.py
@@ -158,6 +158,7 @@ class TeslaCarAsleep(TeslaCarEntity, BinarySensorEntity):
         super().__init__(hass, car, coordinator)
         self.type = "asleep"
         self._attr_device_class = None
+        self._attr_icon = "mdi:sleep"
 
     @property
     def is_on(self):


### PR DESCRIPTION
I forgot to add this to #361, this sets the icon to be more relevant to the sensor, rather than using the generic circle icon.