### PR TITLE
feat: show software update statuses in version info

### DIFF
--- a/tests/mock_data/car.py
+++ b/tests/mock_data/car.py
@@ -215,8 +215,8 @@ VEHICLE_DATA = {
             "download_perc": 0,
             "expected_duration_sec": 2700,
             "install_perc": 1,
-            "status": "",
-            "version": "2022.8.10.1",
+            "status": "available",
+            "version": "2022.36.20",
         },
         "speed_limit_mode": {
             "active": False,

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,10 +1,12 @@
 """Tests for the Tesla update."""
 from unittest.mock import patch
+import pytest
 
 from homeassistant.components.update import DOMAIN as UPDATE_DOMAIN
 
-# from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
@@ -20,35 +22,187 @@ async def test_registry_entries(hass: HomeAssistant) -> None:
     assert entry.unique_id == f"{car_mock_data.VIN.lower()}_software_update"
 
 
-async def test_software_update_properties(hass: HomeAssistant) -> None:
-    """Tests software update properties."""
+async def test_status_download_wait_wifi(hass: HomeAssistant) -> None:
+    """Tests waiting on wifi status"""
+    car_mock_data.VEHICLE_DATA["vehicle_state"]["software_update"] = {
+        "download_perc": 0,
+        "expected_duration_sec": 2700,
+        "install_perc": 1,
+        "status": "downloading_wifi_wait",
+        "version": "2022.36.20",
+    }
     await setup_platform(hass, UPDATE_DOMAIN)
 
-    version = car_mock_data.VEHICLE_DATA["vehicle_state"]["software_update"]["version"]
-
     state = hass.states.get("update.my_model_s_software_update")
-    # assert state.state == str(car_mock_data.VEHICLE_STATE["software_update"])
-
-    assert state.attributes.get("latest_version") == version
-
+    assert state.state == "on"
+    assert state.attributes.get("latest_version") == "2022.36.20 (Waiting on Wi-Fi)"
+    assert state.attributes.get("installed_version") == "2022.8.10.1"
+    assert state.attributes.get("in_progress") is False
     assert (
         state.attributes.get("release_url")
-        == f"https://www.notateslaapp.com/software-updates/version/{version}/release-notes"
+        == "https://www.notateslaapp.com/software-updates/version/2022.36.20/release-notes"
     )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            "install",
+            {ATTR_ENTITY_ID: "update.my_model_s_software_update"},
+            blocking=True,
+        )
 
 
-# async def test_install(hass: HomeAssistant) -> None:
-#     """Tests install update."""
-#     await setup_platform(hass, UPDATE_DOMAIN)
+async def test_status_downloading(hass: HomeAssistant) -> None:
+    """Tests downloading status"""
+    car_mock_data.VEHICLE_DATA["vehicle_state"]["software_update"] = {
+        "download_perc": 50,
+        "expected_duration_sec": 2700,
+        "install_perc": 1,
+        "status": "downloading",
+        "version": "2022.36.20",
+    }
+    await setup_platform(hass, UPDATE_DOMAIN)
 
-#     with patch(
-#         "teslajsonpy.car.TeslaCar.schedule_software_update"
-#     ) as mock_schedule_software_update:
+    state = hass.states.get("update.my_model_s_software_update")
+    assert state.state == "on"
+    assert state.attributes.get("latest_version") == "2022.36.20 (Downloading)"
+    assert state.attributes.get("installed_version") == "2022.8.10.1"
+    assert state.attributes.get("in_progress") is False
+    assert (
+        state.attributes.get("release_url")
+        == "https://www.notateslaapp.com/software-updates/version/2022.36.20/release-notes"
+    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            "install",
+            {ATTR_ENTITY_ID: "update.my_model_s_software_update"},
+            blocking=True,
+        )
 
-#         assert await hass.services.async_call(
-#             UPDATE_DOMAIN,
-#             "install",
-#             {ATTR_ENTITY_ID: "update.my_model_s_software_update"},
-#             blocking=True,
-#         )
-#         mock_schedule_software_update.assert_awaited_once()
+
+async def test_status_available(hass: HomeAssistant) -> None:
+    """Tests available status"""
+    car_mock_data.VEHICLE_DATA["vehicle_state"]["software_update"] = {
+        "download_perc": 100,
+        "expected_duration_sec": 2700,
+        "install_perc": 10,
+        "status": "available",
+        "version": "2022.36.20",
+    }
+    await setup_platform(hass, UPDATE_DOMAIN)
+
+    state = hass.states.get("update.my_model_s_software_update")
+    assert state.state == "on"
+    assert state.attributes.get("latest_version") == "2022.36.20 (Available to install)"
+    assert state.attributes.get("installed_version") == "2022.8.10.1"
+    assert state.attributes.get("in_progress") is False
+    assert (
+        state.attributes.get("release_url")
+        == "https://www.notateslaapp.com/software-updates/version/2022.36.20/release-notes"
+    )
+    with patch(
+        "teslajsonpy.car.TeslaCar.schedule_software_update"
+    ) as mock_schedule_software_update:
+
+        assert await hass.services.async_call(
+            UPDATE_DOMAIN,
+            "install",
+            {ATTR_ENTITY_ID: "update.my_model_s_software_update"},
+            blocking=True,
+        )
+        mock_schedule_software_update.assert_awaited_once()
+
+
+async def test_status_scheduled(hass: HomeAssistant) -> None:
+    """Tests scheduled status"""
+    car_mock_data.VEHICLE_DATA["vehicle_state"]["software_update"] = {
+        "download_perc": 100,
+        "expected_duration_sec": 2700,
+        "install_perc": 10,
+        "scheduled_time_ms": 1669209103248,
+        "status": "scheduled",
+        "version": "2022.36.20",
+        "warning_time_remaining_ms": 70509,
+    }
+    await setup_platform(hass, UPDATE_DOMAIN)
+
+    state = hass.states.get("update.my_model_s_software_update")
+    assert state.state == "on"
+    assert (
+        state.attributes.get("latest_version") == "2022.36.20 (Scheduled for install)"
+    )
+    assert state.attributes.get("installed_version") == "2022.8.10.1"
+    assert state.attributes.get("in_progress") is False
+    assert (
+        state.attributes.get("release_url")
+        == "https://www.notateslaapp.com/software-updates/version/2022.36.20/release-notes"
+    )
+    with patch(
+        "teslajsonpy.car.TeslaCar.schedule_software_update"
+    ) as mock_schedule_software_update:
+
+        assert await hass.services.async_call(
+            UPDATE_DOMAIN,
+            "install",
+            {ATTR_ENTITY_ID: "update.my_model_s_software_update"},
+            blocking=True,
+        )
+        mock_schedule_software_update.assert_awaited_once()
+
+
+async def test_status_installing(hass: HomeAssistant) -> None:
+    """Tests installing status"""
+    car_mock_data.VEHICLE_DATA["vehicle_state"]["software_update"] = {
+        "download_perc": 100,
+        "expected_duration_sec": 2700,
+        "install_perc": 30,
+        "status": "installing",
+        "version": "2022.36.20",
+    }
+    await setup_platform(hass, UPDATE_DOMAIN)
+
+    state = hass.states.get("update.my_model_s_software_update")
+    assert state.state == "on"
+    assert state.attributes.get("latest_version") == "2022.36.20 (Installing)"
+    assert state.attributes.get("installed_version") == "2022.8.10.1"
+    assert state.attributes.get("in_progress") == 30
+    assert (
+        state.attributes.get("release_url")
+        == "https://www.notateslaapp.com/software-updates/version/2022.36.20/release-notes"
+    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            "install",
+            {ATTR_ENTITY_ID: "update.my_model_s_software_update"},
+            blocking=True,
+        )
+
+
+async def test_status_none(hass: HomeAssistant) -> None:
+    """Tests no update"""
+    car_mock_data.VEHICLE_DATA["vehicle_state"]["software_update"] = {
+        "download_perc": 0,
+        "expected_duration_sec": 2700,
+        "install_perc": 1,
+        "status": "",
+        "version": "2022.8.10.1",
+    }
+    await setup_platform(hass, UPDATE_DOMAIN)
+
+    state = hass.states.get("update.my_model_s_software_update")
+    assert state.state == "off"
+    assert state.attributes.get("latest_version") == "2022.8.10.1"
+    assert state.attributes.get("installed_version") == "2022.8.10.1"
+    assert state.attributes.get("in_progress") is False
+    assert (
+        state.attributes.get("release_url")
+        == "https://www.notateslaapp.com/software-updates/version/2022.8.10.1/release-notes"
+    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            "install",
+            {ATTR_ENTITY_ID: "update.my_model_s_software_update"},
+            blocking=True,
+        )


### PR DESCRIPTION
I had a software update last night, so I seized the opportunity to collect api responses of the different states, and provide some improvements to the update component.

This makes a few improvements:
- Ensures the install button isn't available until the update is downloaded (it is hidden when waiting on wifi or still downloading)
- Ensures the install button is available when the update is scheduled, in case the user wants to install immediately.
- Shows the status (Downloading, Waiting on Wi-Fi, etc) in the latest version string to indicate to the user why the install button is not yet available, or to show if it's already scheduled.
- No longer shows as "Installing" when it's scheduled, #356 

Some examples
![image](https://user-images.githubusercontent.com/54586926/203569320-9fcbc115-460c-44b2-80ae-6533a802dac7.png)

![image](https://user-images.githubusercontent.com/54586926/203569435-2f7b54c5-454d-4780-9d9e-452ab862156b.png)

![image](https://user-images.githubusercontent.com/54586926/203569577-0b73a359-5754-4bac-a7dc-b9d5ed0b59a6.png)

![image](https://user-images.githubusercontent.com/54586926/203569212-d2ea6a27-c83d-4610-b1c6-6d54a304eb51.png)

![image](https://user-images.githubusercontent.com/54586926/203569792-1dfcd731-fca7-4c96-9b12-a5a0a8ac9eb3.png)
