### PR TITLE
fix: use utc time zone for charge complete sensor

### DIFF
--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -491,7 +491,7 @@ class TeslaCarTimeChargeComplete(TeslaCarEntity, SensorEntity):
         else:
             charge_hours = float(self._car.time_to_full_charge)
         if self._car.charging_state == "Charging" and charge_hours > 0:
-            new_value = dt.now() + timedelta(hours=charge_hours)
+            new_value = dt.utcnow() + timedelta(hours=charge_hours)
             if self._value is None or (new_value - self._value).total_seconds() >= 60:
                 self._value = new_value
         if self._car.charging_state in ["Charging", "Complete"]:


### PR DESCRIPTION
Looks like HA stores all times in UTC then converts that value to the user's timezone. So using utcnow() instead of now() fixes the timezone issue with this sensor.

closes #374