### PR TITLE
fix: #394 Fixed counterintuitive arrows for window cover

### DIFF
--- a/custom_components/tesla_custom/cover.py
+++ b/custom_components/tesla_custom/cover.py
@@ -164,7 +164,7 @@ class TeslaCarWindows(TeslaCarEntity, CoverEntity):
         """Initialize window cover entity."""
         super().__init__(hass, car, coordinator)
         self.type = "windows"
-        self._attr_device_class = CoverDeviceClass.WINDOW
+        self._attr_device_class = CoverDeviceClass.AWNING
         self._attr_icon = "mdi:window-closed"
         self._attr_supported_features = (
             CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE

--- a/custom_components/tesla_custom/cover.py
+++ b/custom_components/tesla_custom/cover.py
@@ -165,7 +165,7 @@ class TeslaCarWindows(TeslaCarEntity, CoverEntity):
         super().__init__(hass, car, coordinator)
         self.type = "windows"
         self._attr_device_class = CoverDeviceClass.AWNING
-        self._attr_icon = "mdi:window-closed"
+        self._attr_icon = "mdi:car-door"
         self._attr_supported_features = (
             CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
         )


### PR DESCRIPTION
Updated device class for car windows to fix counterintuitive arrows. I also changed the entity icon to better reflect a car window. I will be following this up with a PR to HA to request a device class more suited for car windows.