### PR TITLE
fix: always show charge energy for current and last session

### DIFF
--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -164,9 +164,9 @@ class TeslaCarChargerEnergy(TeslaCarEntity, SensorEntity):
     @property
     def native_value(self) -> float:
         """Return the charge energy added."""
-        if self._car.charging_state == "Charging":
-            return self._car.charge_energy_added
-        return "0"
+        # The car will reset this to 0 automatically when charger
+        # goes from disconnected to connected
+        return self._car.charge_energy_added
 
     @property
     def extra_state_attributes(self):


### PR DESCRIPTION
Fixes #295 and #413 

Based on the information [here](https://developers.home-assistant.io/docs/core/entity/sensor/#entities-representing-a-total-amount), I realized that the logic to set the energy added to 0 when not charging was breaking energy calculations.

The actual energy added value is reset by tesla on it's own, so when we manually set 0, and then revert back to the tesla's value if charging starts again for the same charge session, it will cause the energy dashboard to incorrectly sum the deltas.

It appears that TOTAL_INCREASING is the right state class to use, as we don't expect the value to decrease substantially (a 10% allowance is built in). So if we just rely on the car's own charging state to reset appropriately, the energy dashboard should reflect usage correctly.

What this changes for users:
- The energy added sensor will continue to report the last energy added value from the most recent charging session
- The energy dashboard will no longer double/triple the energy usage for single charging sessions which pause/resume
- The energy added sensor will show unknown instead of 0 when the data is not available (if the vehicle is offline/asleep when the integration is loaded)

### Test plan

Tested in dev container with a model 3:
- ensured while unplugged, the energy_added sensor still showed the last value from the previous charging session
- ensured that upon plugging in a charger, the energy_added sensor reset to 0
- ensured the energy_added sensor increased as it charged
- ensured that when pausing charging (remaining plugged in) the energy_added sensor did not reset to 0
- let the car sleep while plugged in then reloaded integration to get an "unknown" state for energey_added sensor
- woke the car up and ensured the energy_added sensor reflected the last value
- at the end of the charging session, ensured that the energy dashboard amount reflected the actual sensor

energy_added sensor showing that it did not reset to zero when pausing (the blank area is "Unknown" from reloading while asleep)
![image](https://user-images.githubusercontent.com/54586926/206608917-d39888e5-b44e-4e95-90a7-9fb875457eda.png)

The energy dashboard value matches the sensor (it did not double it, even after the "unknown" period)
![image](https://user-images.githubusercontent.com/54586926/206608977-547c517e-1e86-4ebe-9646-05f1247e7382.png)
