### PR TITLE
fix: use old pressure unit consts for ha < 2022.11

### DIFF
--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -16,10 +16,11 @@ from homeassistant.const import (
     PERCENTAGE,
     POWER_WATT,
     POWER_KILO_WATT,
+    PRESSURE_BAR,
+    PRESSURE_PSI,
     SPEED_MILES_PER_HOUR,
     TEMP_CELSIUS,
     TIME_HOURS,
-    UnitOfPressure,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.icon import icon_for_battery_level
@@ -534,8 +535,8 @@ class TeslaCarTpmsPressureSensor(TeslaCarEntity, SensorEntity):
         self.type = tpms_sensor
         self._attr_device_class = SensorDeviceClass.PRESSURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_native_unit_of_measurement = UnitOfPressure.BAR
-        self._attr_suggested_unit_of_measurement = UnitOfPressure.PSI
+        self._attr_native_unit_of_measurement = PRESSURE_BAR
+        self._attr_suggested_unit_of_measurement = PRESSURE_PSI
         self._attr_icon = "mdi:gauge-full"
 
     @property

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -14,11 +14,12 @@ from homeassistant.const import (
     LENGTH_MILES,
     PERCENTAGE,
     POWER_WATT,
+    PRESSURE_BAR,
+    PRESSURE_PSI,
     SPEED_KILOMETERS_PER_HOUR,
     SPEED_MILES_PER_HOUR,
     STATE_UNKNOWN,
     TEMP_CELSIUS,
-    UnitOfPressure,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -401,8 +402,8 @@ async def test_tpms_pressure_sensor(hass: HomeAssistant) -> None:
                 round(
                     car_mock_data.VEHICLE_DATA["vehicle_state"]["tpms_pressure_fl"], 2
                 ),
-                UnitOfPressure.BAR,
-                UnitOfPressure.PSI,
+                PRESSURE_BAR,
+                PRESSURE_PSI,
             ),
             prec,
         ),
@@ -410,7 +411,7 @@ async def test_tpms_pressure_sensor(hass: HomeAssistant) -> None:
 
     assert state_fl.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PRESSURE
     assert state_fl.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
-    assert state_fl.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPressure.PSI
+    assert state_fl.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PRESSURE_PSI
 
     assert (
         state_fl.attributes.get("tpms_last_seen_pressure_timestamp")
@@ -431,8 +432,8 @@ async def test_tpms_pressure_sensor(hass: HomeAssistant) -> None:
                 round(
                     car_mock_data.VEHICLE_DATA["vehicle_state"]["tpms_pressure_fr"], 2
                 ),
-                UnitOfPressure.BAR,
-                UnitOfPressure.PSI,
+                PRESSURE_BAR,
+                PRESSURE_PSI,
             ),
             prec,
         ),
@@ -440,7 +441,7 @@ async def test_tpms_pressure_sensor(hass: HomeAssistant) -> None:
 
     assert state_fr.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PRESSURE
     assert state_fr.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
-    assert state_fr.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPressure.PSI
+    assert state_fr.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PRESSURE_PSI
 
     assert (
         state_fr.attributes.get("tpms_last_seen_pressure_timestamp")
@@ -461,8 +462,8 @@ async def test_tpms_pressure_sensor(hass: HomeAssistant) -> None:
                 round(
                     car_mock_data.VEHICLE_DATA["vehicle_state"]["tpms_pressure_rl"], 2
                 ),
-                UnitOfPressure.BAR,
-                UnitOfPressure.PSI,
+                PRESSURE_BAR,
+                PRESSURE_PSI,
             ),
             prec,
         ),
@@ -470,7 +471,7 @@ async def test_tpms_pressure_sensor(hass: HomeAssistant) -> None:
 
     assert state_rl.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PRESSURE
     assert state_rl.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
-    assert state_rl.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPressure.PSI
+    assert state_rl.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PRESSURE_PSI
 
     assert (
         state_rl.attributes.get("tpms_last_seen_pressure_timestamp")
@@ -491,8 +492,8 @@ async def test_tpms_pressure_sensor(hass: HomeAssistant) -> None:
                 round(
                     car_mock_data.VEHICLE_DATA["vehicle_state"]["tpms_pressure_rr"], 2
                 ),
-                UnitOfPressure.BAR,
-                UnitOfPressure.PSI,
+                PRESSURE_BAR,
+                PRESSURE_PSI,
             ),
             prec,
         ),
@@ -500,7 +501,7 @@ async def test_tpms_pressure_sensor(hass: HomeAssistant) -> None:
 
     assert state_rr.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PRESSURE
     assert state_rr.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
-    assert state_rr.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPressure.PSI
+    assert state_rr.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PRESSURE_PSI
 
     assert (
         state_rr.attributes.get("tpms_last_seen_pressure_timestamp")
@@ -526,6 +527,6 @@ async def test_tpms_pressure_none(hass: HomeAssistant) -> None:
 
     assert state_fl.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PRESSURE
     assert state_fl.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
-    assert state_fl.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPressure.PSI
+    assert state_fl.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PRESSURE_PSI
 
     assert state_fl.attributes.get("tpms_last_seen_pressure_timestamp") == None


### PR DESCRIPTION
Fixes the pressure unit imports to be compatible with home assistant versions before 2022.11. this breakage was introduced in #391 

Fixes #417 

The new unit enums were only released in 2022.11, and many users have not upgraded to this yet
https://developers.home-assistant.io/blog/2022/10/26/new-unit-enumerators/

There does not yet appear to be an announcement that the old units are being removed, so we can continue using them for now.