### PR TITLE
fix: default to 0 miles to arrival when active route unavailable

### DIFF
--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -640,5 +640,5 @@ class TeslaCarDistanceToArrival(TeslaCarEntity, SensorEntity):
     def native_value(self) -> float:
         """Return the distance to arrival."""
         if self._car.active_route_miles_to_arrival is None:
-            return None
+            return 0
         return round(self._car.active_route_miles_to_arrival, 2)


### PR DESCRIPTION
Having used the new feature I'm now thinking that returning 0 makes more sense when the active route fields are not available. 

The current behavior has the distance to arrival slowly dropping as the destination is approached then it becomes unavailable at a random number depending on the last update. 

The new behavior will have the distance to arrival slowly dropping until the destination is reached and then going to zero. This will show that either the destination has been reached and/or that the car does not have an active route. 