### PR TITLE
fix: seat map different for auto climate command vs remote seat command

### DIFF
--- a/custom_components/tesla_custom/select.py
+++ b/custom_components/tesla_custom/select.py
@@ -62,6 +62,11 @@ SEAT_ID_MAP = {
     "third row right": 7,
 }
 
+AUTO_SEAT_ID_MAP = {
+    "left": 1,
+    "right": 2,
+}
+
 
 async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entities):
     """Set up the Tesla selects by config_entry."""
@@ -118,12 +123,12 @@ class TeslaCarHeatedSeat(TeslaCarEntity, SelectEntity):
         if self._is_auto_available and option == FRONT_HEATER_OPTIONS[4]:
             _LOGGER.debug("Setting %s to %s", SEAT_ID_MAP[self._seat_name], option)
             await self._car.remote_auto_seat_climate_request(
-                SEAT_ID_MAP[self._seat_name], True
+                AUTO_SEAT_ID_MAP[self._seat_name], True
             )
         else:
             if self.current_option == FRONT_HEATER_OPTIONS[4]:
                 await self._car.remote_auto_seat_climate_request(
-                    SEAT_ID_MAP[self._seat_name], False
+                    AUTO_SEAT_ID_MAP[self._seat_name], False
                 )
 
             level: int = HEATER_OPTIONS.index(option)

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -84,7 +84,7 @@ async def test_car_heated_seat_select(hass: HomeAssistant) -> None:
             {ATTR_ENTITY_ID: "select.my_model_s_heated_seat_left", "option": "Auto"},
             blocking=True,
         )
-        mock_remote_auto_seat_climate_request.assert_awaited_once_with(0, True)
+        mock_remote_auto_seat_climate_request.assert_awaited_once_with(1, True)
         # Test from "Auto" selection
         car_mock_data.VEHICLE_DATA["climate_state"]["auto_seat_climate_left"] = True
         assert await hass.services.async_call(
@@ -93,7 +93,7 @@ async def test_car_heated_seat_select(hass: HomeAssistant) -> None:
             {ATTR_ENTITY_ID: "select.my_model_s_heated_seat_left", "option": "Low"},
             blocking=True,
         )
-        mock_remote_auto_seat_climate_request.assert_awaited_with(0, False)
+        mock_remote_auto_seat_climate_request.assert_awaited_with(1, False)
 
     with patch("teslajsonpy.car.TeslaCar.set_hvac_mode") as mock_set_hvac_mode:
         # Test climate_on check


### PR DESCRIPTION
Will need to make sure this fully addresses https://github.com/alandtse/tesla/issues/433