### PR TITLE
fix: remove state class from timestamp sensors

### DIFF
--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -501,7 +501,6 @@ class TeslaCarTimeChargeComplete(TeslaCarEntity, SensorEntity):
         super().__init__(hass, car, coordinator)
         self.type = "time charge complete"
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
-        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_icon = "mdi:timer-plus"
         self._value: Optional[datetime] = None
 
@@ -574,7 +573,6 @@ class TeslaCarArrivalTime(TeslaCarEntity, SensorEntity):
         super().__init__(hass, car, coordinator)
         self.type = "arrival time"
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
-        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_icon = "mdi:timer-sand"
         self._datetime_value: Optional[datetime] = None
         self._last_known_value: Optional[int] = None

--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -1,4 +1,8 @@
 """Support for the Tesla sensors."""
+
+from datetime import datetime, timedelta
+from typing import Optional
+
 from teslajsonpy.car import TeslaCar
 from teslajsonpy.const import RESOURCE_TYPE_SOLAR, RESOURCE_TYPE_BATTERY
 from teslajsonpy.energy import EnergySite, PowerwallSite
@@ -20,19 +24,15 @@ from homeassistant.const import (
     PRESSURE_PSI,
     SPEED_MILES_PER_HOUR,
     TEMP_CELSIUS,
-    TIME_HOURS,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.icon import icon_for_battery_level
-from homeassistant.util.unit_conversion import DistanceConverter, PressureConverter
+from homeassistant.util.unit_conversion import DistanceConverter
 from homeassistant.util import dt
 
 from . import TeslaDataUpdateCoordinator
 from .base import TeslaCarEntity, TeslaEnergyEntity
 from .const import DISTANCE_UNITS_KM_HR, DOMAIN
-
-from datetime import datetime, timedelta
-from typing import Optional
 
 SOLAR_SITE_SENSORS = ["solar power", "grid power", "load power"]
 BATTERY_SITE_SENSORS = SOLAR_SITE_SENSORS + ["battery power"]
@@ -586,14 +586,13 @@ class TeslaCarArrivalTime(TeslaCarEntity, SensorEntity):
         else:
             min_duration = round(float(self._car.active_route_minutes_to_arrival), 2)
 
+        utcnow = dt.utcnow()
         if self._last_known_value != min_duration:
             self._last_known_value = min_duration
-            self._last_update_time = dt.utcnow()
+            self._last_update_time = utcnow
 
         new_value = (
-            dt.utcnow()
-            + timedelta(minutes=min_duration)
-            - (dt.utcnow() - self._last_update_time)
+            utcnow + timedelta(minutes=min_duration) - (utcnow - self._last_update_time)
         )
         if (
             self._datetime_value is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -251,7 +251,7 @@ async def test_time_charge_complete_charging(hass: HomeAssistant) -> None:
     assert state.state == charge_complete_str
 
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP
-    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
 
 async def test_time_charge_completed(hass: HomeAssistant) -> None:
@@ -558,7 +558,7 @@ async def test_arrival_time(hass: HomeAssistant) -> None:
     assert state.state == arrival_time_str
 
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP
-    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
     assert (
         state.attributes.get("Energy at arrival")
         == car_mock_data.VEHICLE_DATA["drive_state"]["active_route_energy_at_arrival"]


### PR DESCRIPTION
I discovered while testing on HA dev branch that there is a new check to ensure only numeric sensors are reporting a state class (core PR 83344)

With this new check, it logs an error message that some of our sensors are non-numeric, but have a state class

```
Traceback (most recent call last):
[...]
  File "/usr/local/python/lib/python3.10/site-packages/homeassistant/components/sensor/__init__.py", line 797, in state
    raise ValueError(
ValueError: Sensor sensor.mystique_time_charge_complete has a state class and thus indicating it has a numeric value; however, it has the non-numeric device class: timestamp
```

This PR fixes this error, and also fixes the history graphs for these sensors to not try to map the timestamp to a line chart (which results in unreadable values on the chart as it's converting the timestamp to a float)

Additionally this PR fixes a flakey datetime test by mocking `dt.utcnow`