### PR TITLE
feat: add min_to_full_charge attribute

### DIFF
--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -549,6 +549,18 @@ class TeslaCarTimeChargeComplete(TeslaCarEntity, SensorEntity):
             return self._value
         return None
 
+    @property
+    def extra_state_attributes(self):
+        """Return device state attributes."""
+        # pylint: disable=protected-access
+        minutes_to_full_charge = self._car._vehicle_data.get("charge_state", {}).get(
+            "minutes_to_full_charge"
+        )
+
+        return {
+            "minutes_to_full_charge": minutes_to_full_charge,
+        }
+
 
 class TeslaCarTpmsPressureSensor(TeslaCarEntity, SensorEntity):
     """Representation of the Tesla car TPMS Pressure sensor."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -267,6 +267,11 @@ async def test_time_charge_complete_charging(
     )
     charge_complete_str = datetime.strftime(charge_complete, "%Y-%m-%dT%H:%M:%S+00:00")
 
+    minutes_to_full_charge = car_mock_data.VEHICLE_DATA["charge_state"][
+        "minutes_to_full_charge"
+    ]
+    assert state.attributes.get("minutes_to_full_charge") == minutes_to_full_charge
+
 
 async def test_time_charge_completed(hass: HomeAssistant) -> None:
     """Tests time charge complete is the correct value."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -31,8 +31,8 @@ from homeassistant.util.unit_conversion import (
     PressureConverter,
     SpeedConverter,
 )
-from pytest import MonkeyPatch
 import pytest
+from pytest import MonkeyPatch
 
 pytestmark = pytest.mark.asyncio
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -32,6 +32,9 @@ from homeassistant.util.unit_conversion import (
     SpeedConverter,
 )
 from pytest import MonkeyPatch
+import pytest
+
+pytestmark = pytest.mark.asyncio
 
 from .common import setup_platform
 from .mock_data import car as car_mock_data, energysite as energysite_mock_data


### PR DESCRIPTION
Passing minutes_to_full_charge as an attribute of time_charge_complete sensor.

Still investigating the behavior seen in https://github.com/alandtse/tesla/issues/497