### PR TITLE
fix: use Home Assistant ssl context to avoid I/O

### DIFF
--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -39,6 +39,7 @@ from .const import (
     PLATFORMS,
 )
 from .services import async_setup_services, async_unload_services
+from .util import SSL_CONTEXT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -126,7 +127,9 @@ async def async_setup_entry(hass, config_entry):
     config = config_entry.data
     # Because users can have multiple accounts, we always
     # create a new session so they have separate cookies
-    async_client = httpx.AsyncClient(headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60)
+    async_client = httpx.AsyncClient(
+        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=SSL_CONTEXT
+    )
     email = config_entry.title
 
     if not hass.data[DOMAIN]:

--- a/custom_components/tesla_custom/config_flow.py
+++ b/custom_components/tesla_custom/config_flow.py
@@ -34,6 +34,7 @@ from .const import (
     DOMAIN,
     MIN_SCAN_INTERVAL,
 )
+from .util import SSL_CONTEXT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -173,7 +174,9 @@ async def validate_input(hass: core.HomeAssistant, data) -> dict:
     """
 
     config = {}
-    async_client = httpx.AsyncClient(headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60)
+    async_client = httpx.AsyncClient(
+        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=SSL_CONTEXT
+    )
 
     try:
         controller = TeslaAPI(

--- a/custom_components/tesla_custom/util.py
+++ b/custom_components/tesla_custom/util.py
@@ -1,0 +1,11 @@
+"""Utilities for tesla."""
+
+try:
+    # Home Assistant 2023.4.x+
+    from homeassistant.util.ssl import get_default_context
+
+    SSL_CONTEXT = get_default_context()
+except ImportError:
+    from homeassistant.util.ssl import client_context
+
+    SSL_CONTEXT = client_context()


### PR DESCRIPTION
Creating an ssl context does I/O in the event loop because it reads the ssl certificates from disk.

This is compounded by creating SSLContext leaking memory on some versions of openssl

Try to use the default one if its available to avoid this.