### PR TITLE
fix: use async_create_background_task to close the httpx client

### DIFF
--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -200,7 +200,9 @@ async def async_setup_entry(hass, config_entry):
         # https://docs.python.org/3/library/asyncio-task.html#creating-tasks
 
         if hasattr(hass, "async_create_background_task"):
-            hass.async_create_background_task(_async_close_client())
+            hass.async_create_background_task(
+                _async_close_client(), "tesla_close_client"
+            )
         else:
             asyncio.create_task(_async_close_client())
 

--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -193,7 +193,16 @@ async def async_setup_entry(hass, config_entry):
 
     @callback
     def _async_create_close_task():
-        asyncio.create_task(_async_close_client())
+        # Background tasks are tracked in HA to prevent them from
+        # being garbage collected in the middle of the task since
+        # asyncio only holds a weak reference to them.
+        #
+        # https://docs.python.org/3/library/asyncio-task.html#creating-tasks
+
+        if hasattr(hass, "async_create_background_task"):
+            hass.async_create_background_task(_async_close_client())
+        else:
+            asyncio.create_task(_async_close_client())
 
     config_entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, _async_close_client)


### PR DESCRIPTION
https://docs.python.org/3/library/asyncio-task.html#creating-tasks
> Important Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn’t referenced elsewhere may get garbage collected at any time, even before it’s done. For reliable “fire-and-forget” background tasks, gather them in a collection: