### PR TITLE
feat: Add Shift State Sensor

### DIFF
--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -66,6 +66,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
         entities.append(TeslaCarChargerEnergy(hass, car, coordinator))
         entities.append(TeslaCarChargerPower(hass, car, coordinator))
         entities.append(TeslaCarOdometer(hass, car, coordinator))
+        entities.append(TeslaCarShiftState(hass, car, coordinator))
         entities.append(TeslaCarRange(hass, car, coordinator))
         entities.append(TeslaCarTemp(hass, car, coordinator))
         entities.append(TeslaCarTemp(hass, car, coordinator, inside=True))
@@ -289,6 +290,48 @@ class TeslaCarOdometer(TeslaCarEntity, SensorEntity):
             return None
 
         return round(odometer_value, 2)
+
+
+class TeslaCarShiftState(TeslaCarEntity, SensorEntity):
+    """Representation of the Tesla car Shift State sensor."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        car: TeslaCar,
+        coordinator: TeslaDataUpdateCoordinator,
+    ) -> None:
+        """Initialize odometer entity."""
+        super().__init__(hass, car, coordinator)
+        self.type = "shift state"
+        self._attr_device_class = SensorDeviceClass.ENUM
+        self._attr_icon = "mdi:car-shift-pattern"
+
+    @property
+    def native_value(self) -> float:
+        """Return the shift state."""
+        value = self._car.shift_state
+
+        # When car is parked and off, Tesla API reports shift_state None
+        if value is None or value == "":
+            return "P"
+
+        return value
+
+    @property
+    def options(self) -> float:
+        """Return the values for the ENUM."""
+        values = ["P", "D", "R", "N"]
+
+        return values
+
+    @property
+    def extra_state_attributes(self):
+        """Return device state attributes."""
+
+        return {
+            "raw_state": self._car.shift_state,
+        }
 
 
 class TeslaCarRange(TeslaCarEntity, SensorEntity):

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Tesla",
   "hacs": "1.6.0",
-  "homeassistant": "2022.11.0",
+  "homeassistant": "2023.2.0",
   "zip_release": true,
   "filename": "tesla_custom.zip"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Tesla",
   "hacs": "1.6.0",
-  "homeassistant": "2023.2.0",
+  "homeassistant": "2023.1.0",
   "zip_release": true,
   "filename": "tesla_custom.zip"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ teslajsonpy = "^3.8.0"
 
 
 [tool.poetry.group.dev.dependencies]
-homeassistant = ">=2023.2.0"
+homeassistant = ">=2023.1.0"
 pytest-homeassistant-custom-component = ">=0.13.1"
 bandit = ">=1.7.0"
 black = {version = ">=21.12b0", allow-prereleases = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ teslajsonpy = "^3.8.0"
 
 
 [tool.poetry.group.dev.dependencies]
-homeassistant = ">=2022.11.0"
+homeassistant = ">=2023.2.0"
 pytest-homeassistant-custom-component = ">=0.13.1"
 bandit = ">=1.7.0"
 black = {version = ">=21.12b0", allow-prereleases = true}


### PR DESCRIPTION
Add a car Shift state ENUM sensor, so you can detect what gear the car is in specifically.

This is different to the Parking Break binary sensor, as you get the explicit gear.