### PR TITLE
fix: Update state with earlier charge complete and arrival times

### DIFF
--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -686,7 +686,7 @@ class TeslaCarArrivalTime(TeslaCarEntity, SensorEntity):
         )
         if (
             self._datetime_value is None
-            or (new_value - self._datetime_value).total_seconds() >= 60
+            or abs((new_value - self._datetime_value).total_seconds()) >= 60
         ):
             self._datetime_value = new_value
         return self._datetime_value

--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -591,7 +591,10 @@ class TeslaCarTimeChargeComplete(TeslaCarEntity, SensorEntity):
                 + timedelta(hours=charge_hours)
                 - (dt.utcnow() - self._last_update_time)
             )
-            if self._value is None or (new_value - self._value).total_seconds() >= 60:
+            if (
+                self._value is None
+                or abs((new_value - self._value).total_seconds()) >= 60
+            ):
                 self._value = new_value
         if self._car.charging_state in ["Charging", "Complete"]:
             return self._value

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -260,7 +260,7 @@ async def test_time_charge_complete_charging(
 
     assert state.state == charge_complete_str
 
-    car_mock_data.VEHICLE_DATA["charge_state"]["time_to_full_charge"] -= 0.1
+    car_mock_data.VEHICLE_DATA["charge_state"]["time_to_full_charge"] = 0.15
     earlier_charge_complete = mock_now + timedelta(
         hours=float(car_mock_data.VEHICLE_DATA["charge_state"]["time_to_full_charge"])
     )
@@ -617,7 +617,7 @@ async def test_arrival_time(hass: HomeAssistant, monkeypatch: MonkeyPatch) -> No
 
     assert state.state == arrival_time_str
 
-    car_mock_data.VEHICLE_DATA["drive_state"]["active_route_minutes_to_arrival"] -= 2
+    car_mock_data.VEHICLE_DATA["drive_state"]["active_route_minutes_to_arrival"] = 32.16
     earlier_arrival_time = mock_now + timedelta(
         minutes=round(
             float(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -260,17 +260,6 @@ async def test_time_charge_complete_charging(
 
     assert state.state == charge_complete_str
 
-    car_mock_data.VEHICLE_DATA["charge_state"]["time_to_full_charge"] = 0.15
-    earlier_charge_complete = mock_now + timedelta(
-        hours=float(car_mock_data.VEHICLE_DATA["charge_state"]["time_to_full_charge"])
-    )
-    earlier_charge_complete_str = datetime.strftime(
-        earlier_charge_complete, "%Y-%m-%dT%H:%M:%S+00:00"
-    )
-
-    state = hass.states.get("sensor.my_model_s_time_charge_complete")
-    assert state.state == earlier_charge_complete_str
-
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP
     assert state.attributes.get(ATTR_STATE_CLASS) is None
 
@@ -616,24 +605,6 @@ async def test_arrival_time(hass: HomeAssistant, monkeypatch: MonkeyPatch) -> No
     arrival_time_str = datetime.strftime(arrival_time, "%Y-%m-%dT%H:%M:%S+00:00")
 
     assert state.state == arrival_time_str
-
-    car_mock_data.VEHICLE_DATA["drive_state"]["active_route_minutes_to_arrival"] = 32.16
-    earlier_arrival_time = mock_now + timedelta(
-        minutes=round(
-            float(
-                car_mock_data.VEHICLE_DATA["drive_state"][
-                    "active_route_minutes_to_arrival"
-                ]
-            ),
-            2,
-        )
-    )
-    earlier_arrival_time_str = datetime.strftime(
-        earlier_arrival_time, "%Y-%m-%dT%H:%M:%S+00:00"
-    )
-
-    state = hass.states.get("sensor.my_model_s_arrival_time")
-    assert state.state == earlier_arrival_time_str
 
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP
     assert state.attributes.get(ATTR_STATE_CLASS) is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -617,6 +617,24 @@ async def test_arrival_time(hass: HomeAssistant, monkeypatch: MonkeyPatch) -> No
 
     assert state.state == arrival_time_str
 
+    car_mock_data.VEHICLE_DATA["drive_state"]["active_route_minutes_to_arrival"] -= 2
+    earlier_arrival_time = mock_now + timedelta(
+        minutes=round(
+            float(
+                car_mock_data.VEHICLE_DATA["drive_state"][
+                    "active_route_minutes_to_arrival"
+                ]
+            ),
+            2,
+        )
+    )
+    earlier_arrival_time_str = datetime.strftime(
+        earlier_arrival_time, "%Y-%m-%dT%H:%M:%S+00:00"
+    )
+
+    state = hass.states.get("sensor.my_model_s_arrival_time")
+    assert state.state == earlier_arrival_time_str
+
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP
     assert state.attributes.get(ATTR_STATE_CLASS) is None
     assert (

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -260,6 +260,17 @@ async def test_time_charge_complete_charging(
 
     assert state.state == charge_complete_str
 
+    car_mock_data.VEHICLE_DATA["charge_state"]["time_to_full_charge"] -= 0.1
+    earlier_charge_complete = mock_now + timedelta(
+        hours=float(car_mock_data.VEHICLE_DATA["charge_state"]["time_to_full_charge"])
+    )
+    earlier_charge_complete_str = datetime.strftime(
+        earlier_charge_complete, "%Y-%m-%dT%H:%M:%S+00:00"
+    )
+
+    state = hass.states.get("sensor.my_model_s_time_charge_complete")
+    assert state.state == earlier_charge_complete_str
+
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP
     assert state.attributes.get(ATTR_STATE_CLASS) is None
 


### PR DESCRIPTION
Added absolute value around the seconds comparison to allow for a state change when the charge complete time and the arrival time move earlier than before. 

closes https://github.com/alandtse/tesla/issues/565