### PR TITLE
fix: Debounce teslamate updates

### DIFF
--- a/custom_components/tesla_custom/teslamate.py
+++ b/custom_components/tesla_custom/teslamate.py
@@ -297,22 +297,22 @@ class TeslaMate:
         if mqtt_attr in MAP_DRIVE_STATE:
             attr, cast = MAP_DRIVE_STATE[mqtt_attr]
             self.update_drive_state(car, attr, cast(msg.payload))
-            coordinator.async_update_listeners()
+            coordinator.async_update_listeners_debounced()
 
         elif mqtt_attr in MAP_VEHICLE_STATE:
             attr, cast = MAP_VEHICLE_STATE[mqtt_attr]
             self.update_vehicle_state(car, attr, cast(msg.payload))
-            coordinator.async_update_listeners()
+            coordinator.async_update_listeners_debounced()
 
         elif mqtt_attr in MAP_CLIMATE_STATE:
             attr, cast = MAP_CLIMATE_STATE[mqtt_attr]
             self.update_climate_state(car, attr, cast(msg.payload))
-            coordinator.async_update_listeners()
+            coordinator.async_update_listeners_debounced()
 
         elif mqtt_attr in MAP_CHARGE_STATE:
             attr, cast = MAP_CHARGE_STATE[mqtt_attr]
             self.update_charge_state(car, attr, cast(msg.payload))
-            coordinator.async_update_listeners()
+            coordinator.async_update_listeners_debounced()
 
     @staticmethod
     def update_drive_state(car: TeslaCar, attr, value):


### PR DESCRIPTION
This update batches updates from TeslaMate so less calls are made to `async_update_listeners`.

The main reason for this is the destination tracker updates. currently, as Lat and Long are different updates, the location of the Tesla can zig/zag as it moves along a line.

This normalizes that data.

calls to `async_update_listeners` will happen no more than once a second, but no less then once ever 0.1 seconds.

I won't hide the fact that ChatGPT helped me write this code :)