### PR TITLE
feat: enable http/2 support when installed

### DIFF
--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -18,7 +18,6 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.httpx_client import SERVER_SOFTWARE, USER_AGENT
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 import httpx
 from teslajsonpy import Controller as TeslaAPI
@@ -44,7 +43,7 @@ from .const import (
 )
 from .services import async_setup_services, async_unload_services
 from .teslamate import TeslaMate
-from .util import SSL_CONTEXT
+from .util import get_async_client
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -132,9 +131,7 @@ async def async_setup_entry(hass, config_entry):
     config = config_entry.data
     # Because users can have multiple accounts, we always
     # create a new session so they have separate cookies
-    async_client = httpx.AsyncClient(
-        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=SSL_CONTEXT
-    )
+    async_client = get_async_client()
     email = config_entry.title
 
     if not hass.data[DOMAIN]:

--- a/custom_components/tesla_custom/config_flow.py
+++ b/custom_components/tesla_custom/config_flow.py
@@ -12,8 +12,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.httpx_client import SERVER_SOFTWARE, USER_AGENT
-import httpx
 from teslajsonpy import Controller as TeslaAPI, TeslaException
 from teslajsonpy.const import AUTH_DOMAIN
 from teslajsonpy.exceptions import IncompleteCredentials
@@ -36,7 +34,7 @@ from .const import (
     DOMAIN,
     MIN_SCAN_INTERVAL,
 )
-from .util import SSL_CONTEXT
+from .util import get_async_client
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -182,9 +180,7 @@ async def validate_input(hass: core.HomeAssistant, data) -> dict:
     """
 
     config = {}
-    async_client = httpx.AsyncClient(
-        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=SSL_CONTEXT
-    )
+    async_client = get_async_client()
 
     try:
         controller = TeslaAPI(

--- a/custom_components/tesla_custom/util.py
+++ b/custom_components/tesla_custom/util.py
@@ -1,5 +1,16 @@
 """Utilities for tesla."""
 
+from homeassistant.helpers.httpx_client import SERVER_SOFTWARE, USER_AGENT
+import httpx
+
+try:
+    import h2  # pylint: disable=unused-import # noqa: F401
+
+    HAS_H2 = True
+except ImportError:
+    HAS_H2 = False
+
+
 try:
     # Home Assistant 2023.4.x+
     from homeassistant.util.ssl import get_default_context
@@ -9,3 +20,17 @@ except ImportError:
     from homeassistant.util.ssl import client_context
 
     SSL_CONTEXT = client_context()
+
+
+def get_async_client():
+    """Get an async client.
+
+    http2 is preferred since it avoids the overhead of setting up multiple
+    TLS connections which can reduce the chance of hitting a timeout.
+    """
+    return httpx.AsyncClient(
+        headers={USER_AGENT: SERVER_SOFTWARE},
+        timeout=60,
+        verify=SSL_CONTEXT,
+        http2=HAS_H2,
+    )


### PR DESCRIPTION
http/2 reduces the number of TLS handshakes which has reduced the number of timeouts in testing.

This decreased the startup time from 90s to 70s for on of my larger installs.

I have a few power sites and enabling too many of them causes timeouts. Enabling h2 fixed the problem