### PR TITLE
fix: ensure update_vehicles coordinator always polls

### DIFF
--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -296,11 +296,13 @@ async def async_setup_entry(hass, config_entry):
         # to keep the vehicles up to date.
         @callback
         def _async_update_vehicles():
-            """Update vehicles coordinator."""
-            # Schedule all the car coordinators listeners to update
-            # since the vehicles coordinator has updated.
-            for coordinator in car_coordinators.values():
-                coordinator.async_update_listeners_debounced()
+            """Update vehicles coordinator.
+
+            This listener is called when the update_vehicles_coordinator
+            is updated. Since each car coordinator is also polling we don't
+            need to do anything here, but we need to have this listener
+            to ensure the update_vehicles_coordinator is updated regularly.
+            """
 
         update_vehicles_coordinator.async_add_listener(_async_update_vehicles)
 

--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -286,14 +286,11 @@ async def async_setup_entry(hass, config_entry):
         for energy_site_id in energysites
     }
     car_coordinators = {vin: _partial_coordinator(vins={vin}) for vin in cars}
-    coordinators = {
-        "update_vehicles": _partial_coordinator(update_vehicles=True),
-        **energy_coordinators,
-        **car_coordinators,
-    }
+    coordinators = {**energy_coordinators, **car_coordinators}
 
     if car_coordinators:
-        update_vehicles_coordinator = coordinators["update_vehicles"]
+        update_vehicles_coordinator = _partial_coordinator(update_vehicles=True)
+        coordinators["update_vehicles"] = update_vehicles_coordinator
 
         # If we have cars, we want to update the vehicles coordinator
         # to keep the vehicles up to date.

--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -290,6 +290,21 @@ async def async_setup_entry(hass, config_entry):
         **{vin: _partial_coordinator(vins={vin}) for vin in cars},
     }
 
+    update_vehicles_coordinator = coordinators["update_vehicles"]
+
+    if cars:
+        # If we have cars, we want to update the vehicles coordinator
+        # to keep the vehicles up to date.
+        @callback
+        def _async_update_vehicles():
+            """Update vehicles coordinator.
+
+            The coordinator will not update if there is not at least one
+            listener, so we need to add a dummy listener.
+            """
+
+        update_vehicles_coordinator.async_add_listener(_async_update_vehicles)
+
     teslamate = TeslaMate(hass=hass, cars=cars, coordinators=coordinators)
 
     enable_teslamate = config_entry.options.get(

--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -300,7 +300,7 @@ async def async_setup_entry(hass, config_entry):
         @callback
         def _async_update_vehicles():
             """Update vehicles coordinator."""
-            # Schedule all the car coordinators to update
+            # Schedule all the car coordinators listeners to update
             # since the vehicles coordinator has updated.
             for coordinator in car_coordinators.values():
                 coordinator.async_update_listeners_debounced()


### PR DESCRIPTION
Only create the `update_vehicles` coordinator if there are cars to be polled

Add a listener to the `update_vehicles` to ensure we continue to poll the `vehicles` endpoint since the lack of listeners previously meant the endpoint was not being polled.