### PR TITLE
fix: add missing CONFIG_SCHEMA and service translations

### DIFF
--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.httpx_client import SERVER_SOFTWARE, USER_AGENT
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -47,6 +48,8 @@ from .teslamate import TeslaMate
 from .util import SSL_CONTEXT
 
 _LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
 @callback

--- a/custom_components/tesla_custom/services.yaml
+++ b/custom_components/tesla_custom/services.yaml
@@ -1,5 +1,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 api:
+  name: Run API Command
   # Description of the service
   description: Run an API command using controller.api. https://teslajsonpy.readthedocs.io/en/latest/teslajsonpy/teslajsonpy.html#teslajsonpy.Controller.api
   # Different fields that your service accepts
@@ -31,6 +32,7 @@ api:
         object:
 
 polling_interval:
+  name: Set Polling Interval
   description: Set polling interval for updating fresh data from an awake car
   fields:
     email:

--- a/custom_components/tesla_custom/strings.json
+++ b/custom_components/tesla_custom/strings.json
@@ -34,5 +34,25 @@
         }
       }
     }
+  },
+  "services": {
+    "api": {
+      "name": "Run API Command",
+      "description": "Run an API command using controller.api",
+      "fields": {
+        "email": "Email address",
+        "command": "Command",
+        "parameters": "Parameters"
+      }
+    },
+    "polling_interval": {
+      "name": "Set Polling Interval",
+      "description": "Set the polling interval for the Tesla API",
+      "fields": {
+        "scan_interval": "Interval (seconds)",
+        "email": "Email address",
+        "vin": "Vehicle VIN"
+      }
+    }
   }
 }

--- a/custom_components/tesla_custom/strings.json
+++ b/custom_components/tesla_custom/strings.json
@@ -40,18 +40,36 @@
       "name": "Run API Command",
       "description": "Run an API command using controller.api",
       "fields": {
-        "email": "Email address",
-        "command": "Command",
-        "parameters": "Parameters"
+        "email": {
+          "name": "Email address",
+          "description": "Email address (optional if only one account)"
+        },
+        "command": {
+          "name": "Command",
+          "description": "Command to run. See https://github.com/zabuldon/teslajsonpy/blob/master/teslajsonpy/endpoints.json"
+        },
+        "parameters": {
+          "name": "Parameters",
+          "description": "Parameters in a dictionary. `path_vars` replace variables in endpoints.json path. All others are passed directly to controller.api. For command parameters see https://tesla-api.timdorr.com/vehicle/commands."
+        }
       }
     },
     "polling_interval": {
       "name": "Set Polling Interval",
       "description": "Set the polling interval for the Tesla API",
       "fields": {
-        "scan_interval": "Interval (seconds)",
-        "email": "Email address",
-        "vin": "Vehicle VIN"
+        "scan_interval": {
+          "name": "Interval (seconds)",
+          "description": "Number of seconds between each poll.  See https://github.com/alandtse/tesla/wiki/Polling-policy more information."
+        },
+        "email": {
+          "name": "Email address",
+          "description": "Email address (optional if only one account)"
+        },
+        "vin": {
+          "name": "Vehicle VIN",
+          "description": "Vehicle VIN (if not provided then default polling interval will be updated)"
+        }
       }
     }
   }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Tesla",
   "hacs": "1.6.0",
-  "homeassistant": "2023.4.0",
+  "homeassistant": "2023.6.0",
   "zip_release": true,
   "filename": "tesla_custom.zip"
 }


### PR DESCRIPTION
BREAKING CHANGE: Home Assistant Core 2023.6.0 or later is now required

fixes https://github.com/alandtse/tesla/actions/runs/5677167144/job/15385034940

Note: we can't remove from services.yaml since old version still need it