### PR TITLE
fix: Improve a couple of things in MQTT sync from Teslamate

### DIFF
--- a/custom_components/tesla_custom/teslamate.py
+++ b/custom_components/tesla_custom/teslamate.py
@@ -46,16 +46,16 @@ def cast_odometer(odometer: float) -> float:
 
 
 def cast_plugged_in(val: str) -> str:
-    """Convert boolean string for plugged_in value"""
+    """Convert boolean string for plugged_in value."""
     return "Connected" if cast_bool(val) else "Disconnected"
 
 
 def cast_bool(val: str) -> bool:
-    """Convert bool string to actual bool"""
+    """Convert bool string to actual bool."""
     return val.lower() in ["true", "True"]
 
-
 def cast_trunk_open(val: str) -> int:
+    """Convert bool string to trunk/frunk open/close value."""
     return 255 if cast_bool(str) else 0
 
 

--- a/custom_components/tesla_custom/teslamate.py
+++ b/custom_components/tesla_custom/teslamate.py
@@ -44,6 +44,16 @@ def cast_odometer(odometer: float) -> float:
 
     return odometer_miles
 
+def cast_plugged_in(val: str) -> str:
+    """Convert boolean string for plugged_in value"""
+    return "Connected" if cast_bool(val) else "Disconnected"
+
+def cast_bool(val: str) -> bool:
+    """Convert bool string to actual bool"""
+    return val.lower() in ['true', 'True']
+
+def cast_trunk_open(val: str) -> int:
+    return 255 if cast_bool(str) else 0
 
 def cast_speed(speed: int) -> int:
     """Convert KM to Miles.
@@ -70,9 +80,10 @@ MAP_DRIVE_STATE = {
 }
 
 MAP_CLIMATE_STATE = {
-    "is_climate_on": ("is_climate_on", bool),
+    "is_climate_on": ("is_climate_on", cast_bool),
     "inside_temp": ("inside_temp", float),
     "outside_temp": ("outside_temp", float),
+    "is_preconditioning": ("is_preconditioning", cast_bool)
 }
 
 MAP_VEHICLE_STATE = {
@@ -80,9 +91,12 @@ MAP_VEHICLE_STATE = {
     "tpms_pressure_fr": ("tpms_pressure_fr", float),
     "tpms_pressure_rl": ("tpms_pressure_rl", float),
     "tpms_pressure_rr": ("tpms_pressure_rr", float),
-    "locked": ("locked", bool),
-    "sentry_mode": ("sentry_mode", bool),
+    "locked": ("locked", cast_bool),
+    "sentry_mode": ("sentry_mode", cast_bool),
     "odometer": ("odometer", cast_odometer),
+    "trunk_open": ("rt", cast_trunk_open),
+    "frunk_open": ("ft", cast_trunk_open),
+    "is_user_present": ("is_user_present", cast_bool)
 }
 
 MAP_CHARGE_STATE = {
@@ -94,6 +108,8 @@ MAP_CHARGE_STATE = {
     "charger_voltage": ("charger_voltage", int),
     "time_to_full_charge": ("time_to_full_charge", float),
     "charge_limit_soc": ("charge_limit_soc", int),
+    "plugged_in": ("charging_state", cast_plugged_in),
+    "charge_port_door_open": ("charge_port_door_open", cast_bool)
 }
 
 

--- a/custom_components/tesla_custom/teslamate.py
+++ b/custom_components/tesla_custom/teslamate.py
@@ -54,6 +54,7 @@ def cast_bool(val: str) -> bool:
     """Convert bool string to actual bool."""
     return val.lower() in ["true", "True"]
 
+
 def cast_trunk_open(val: str) -> int:
     """Convert bool string to trunk/frunk open/close value."""
     return 255 if cast_bool(str) else 0

--- a/custom_components/tesla_custom/teslamate.py
+++ b/custom_components/tesla_custom/teslamate.py
@@ -44,16 +44,20 @@ def cast_odometer(odometer: float) -> float:
 
     return odometer_miles
 
+
 def cast_plugged_in(val: str) -> str:
     """Convert boolean string for plugged_in value"""
     return "Connected" if cast_bool(val) else "Disconnected"
 
+
 def cast_bool(val: str) -> bool:
     """Convert bool string to actual bool"""
-    return val.lower() in ['true', 'True']
+    return val.lower() in ["true", "True"]
+
 
 def cast_trunk_open(val: str) -> int:
     return 255 if cast_bool(str) else 0
+
 
 def cast_speed(speed: int) -> int:
     """Convert KM to Miles.
@@ -83,7 +87,7 @@ MAP_CLIMATE_STATE = {
     "is_climate_on": ("is_climate_on", cast_bool),
     "inside_temp": ("inside_temp", float),
     "outside_temp": ("outside_temp", float),
-    "is_preconditioning": ("is_preconditioning", cast_bool)
+    "is_preconditioning": ("is_preconditioning", cast_bool),
 }
 
 MAP_VEHICLE_STATE = {
@@ -96,7 +100,7 @@ MAP_VEHICLE_STATE = {
     "odometer": ("odometer", cast_odometer),
     "trunk_open": ("rt", cast_trunk_open),
     "frunk_open": ("ft", cast_trunk_open),
-    "is_user_present": ("is_user_present", cast_bool)
+    "is_user_present": ("is_user_present", cast_bool),
 }
 
 MAP_CHARGE_STATE = {
@@ -109,7 +113,7 @@ MAP_CHARGE_STATE = {
     "time_to_full_charge": ("time_to_full_charge", float),
     "charge_limit_soc": ("charge_limit_soc", int),
     "plugged_in": ("charging_state", cast_plugged_in),
-    "charge_port_door_open": ("charge_port_door_open", cast_bool)
+    "charge_port_door_open": ("charge_port_door_open", cast_bool),
 }
 
 


### PR DESCRIPTION
Fixes #689

- parse boolean strings for is_climate_on, locked, sentry_mode
- add sync for plugged_in
- add sync for charge_port_door_open
- add sync for trunk_open
- add sync for frunk_open
- add sync for is_user_present
- add sync for is_preconditioning