### PR TITLE
feat: Add charge_current_request properties from MQTT

### DIFF
--- a/custom_components/tesla_custom/teslamate.py
+++ b/custom_components/tesla_custom/teslamate.py
@@ -118,6 +118,7 @@ MAP_CHARGE_STATE = {
     "charge_current_request_max": ("charge_current_request_max", int),
 }
 
+
 class TeslaMate:
     """TeslaMate Connector.
 

--- a/custom_components/tesla_custom/teslamate.py
+++ b/custom_components/tesla_custom/teslamate.py
@@ -114,8 +114,9 @@ MAP_CHARGE_STATE = {
     "charge_limit_soc": ("charge_limit_soc", int),
     "plugged_in": ("charging_state", cast_plugged_in),
     "charge_port_door_open": ("charge_port_door_open", cast_bool),
+    "charge_current_request": ("charge_current_request", int),
+    "charge_current_request_max": ("charge_current_request_max", int),
 }
-
 
 class TeslaMate:
     """TeslaMate Connector.


### PR DESCRIPTION
Add sync for `charge_current_request` and `charge_current_request_max` from Teslamate.