### PR TITLE
test: Fix tests

### DIFF
--- a/tests/mock_data/energysite.py
+++ b/tests/mock_data/energysite.py
@@ -477,6 +477,11 @@ BATTERY_DATA = {
     "default_real_mode": "self_consumption",
     "operation": "self_consumption",
     "installation_date": "2022-03-21T17:15:23+10:00",
+    "load_power": 7010,
+    "solar_power": 6638,
+    "grid_power": 2,
+    "battery_power": 370,
+    "generator_power": 0,
     "power_reading": [
         {
             "timestamp": "2022-08-18T15:10:20+10:00",
@@ -496,5 +501,6 @@ BATTERY_SUMMARY = {
     "energy_left": 13610.736842105263,
     "total_pack_energy": 14056,
     "percentage_charged": 96.8322199922116,
-    "battery_power": 400,
+    "battery_power": 370,
+    "grid_status": "Active",
 }

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -78,7 +78,7 @@ async def test_horn_press(hass: HomeAssistant) -> None:
     await setup_platform(hass, BUTTON_DOMAIN)
 
     with patch("teslajsonpy.car.TeslaCar.honk_horn") as mock_honk_horn:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             BUTTON_DOMAIN,
             "press",
             {ATTR_ENTITY_ID: "button.my_model_s_horn"},
@@ -92,7 +92,7 @@ async def test_flash_lights_press(hass: HomeAssistant) -> None:
     await setup_platform(hass, BUTTON_DOMAIN)
 
     with patch("teslajsonpy.car.TeslaCar.flash_lights") as mock_flash_lights:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             BUTTON_DOMAIN,
             "press",
             {ATTR_ENTITY_ID: "button.my_model_s_flash_lights"},
@@ -106,7 +106,7 @@ async def test_wake_up_press(hass: HomeAssistant) -> None:
     await setup_platform(hass, BUTTON_DOMAIN)
 
     with patch("teslajsonpy.car.TeslaCar.wake_up") as mock_wake_up:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             BUTTON_DOMAIN,
             "press",
             {ATTR_ENTITY_ID: "button.my_model_s_wake_up"},
@@ -122,7 +122,7 @@ async def test_force_data_update_press(hass: HomeAssistant) -> None:
     with patch(
         "custom_components.tesla_custom.base.TeslaCarEntity.update_controller"
     ) as mock_force_data_update:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             BUTTON_DOMAIN,
             "press",
             {ATTR_ENTITY_ID: "button.my_model_s_force_data_update"},
@@ -138,7 +138,7 @@ async def test_trigger_homelink_press(hass: HomeAssistant) -> None:
     await setup_platform(hass, BUTTON_DOMAIN)
 
     with patch("teslajsonpy.car.TeslaCar.trigger_homelink") as mock_trigger_homelink:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             BUTTON_DOMAIN,
             "press",
             {ATTR_ENTITY_ID: "button.my_model_s_homelink"},
@@ -152,7 +152,7 @@ async def test_remote_start_press(hass: HomeAssistant) -> None:
     await setup_platform(hass, BUTTON_DOMAIN)
 
     with patch("teslajsonpy.car.TeslaCar.remote_start") as mock_remote_start:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             BUTTON_DOMAIN,
             "press",
             {ATTR_ENTITY_ID: "button.my_model_s_remote_start"},
@@ -166,7 +166,7 @@ async def test_emissions_test_press(hass: HomeAssistant) -> None:
     await setup_platform(hass, BUTTON_DOMAIN)
 
     with patch("teslajsonpy.car.TeslaCar.remote_boombox") as mock_remote_boombox:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             BUTTON_DOMAIN,
             "press",
             {ATTR_ENTITY_ID: "button.my_model_s_emissions_test"},

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -52,7 +52,7 @@ async def test_set_temperature(hass: HomeAssistant) -> None:
     await setup_platform(hass, CLIMATE_DOMAIN)
 
     with patch("teslajsonpy.car.TeslaCar.set_temperature") as mock_set_temperature:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             CLIMATE_DOMAIN,
             "set_temperature",
             {
@@ -69,7 +69,7 @@ async def test_set_hvac_mode(hass: HomeAssistant) -> None:
     await setup_platform(hass, CLIMATE_DOMAIN)
 
     with patch("teslajsonpy.car.TeslaCar.set_hvac_mode") as mock_set_hvac_mode:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             CLIMATE_DOMAIN,
             "set_hvac_mode",
             {
@@ -91,7 +91,7 @@ async def test_set_preset_mode(hass: HomeAssistant) -> None:
         "teslajsonpy.car.TeslaCar.defrost_mode", return_value=1
     ):
         # Test set preset_mode "Normal" with defrost_mode != 0
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             CLIMATE_DOMAIN,
             "set_preset_mode",
             {
@@ -108,7 +108,7 @@ async def test_set_preset_mode(hass: HomeAssistant) -> None:
         "teslajsonpy.car.TeslaCar.climate_keeper_mode", return_value="on"
     ):
         # Test set preset_mode "Normal" with climate_keeper_mode != 0
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             CLIMATE_DOMAIN,
             "set_preset_mode",
             {
@@ -121,7 +121,7 @@ async def test_set_preset_mode(hass: HomeAssistant) -> None:
 
     with patch("teslajsonpy.car.TeslaCar.set_max_defrost") as mock_set_max_defrost:
         # Test set preset_mode "Defrost"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             CLIMATE_DOMAIN,
             "set_preset_mode",
             {
@@ -136,7 +136,7 @@ async def test_set_preset_mode(hass: HomeAssistant) -> None:
         "teslajsonpy.car.TeslaCar.set_climate_keeper_mode"
     ) as mock_set_climate_keeper_mode:
         # Test set preset_mode "Dog Mode"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             CLIMATE_DOMAIN,
             "set_preset_mode",
             {

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -33,7 +33,7 @@ async def test_charger_door(hass: HomeAssistant) -> None:
     await setup_platform(hass, COVER_DOMAIN)
 
     with patch("teslajsonpy.car.TeslaCar.charge_port_door_open") as mock_open_cover:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_OPEN_COVER,
             {ATTR_ENTITY_ID: "cover.my_model_s_charger_door"},
@@ -42,7 +42,7 @@ async def test_charger_door(hass: HomeAssistant) -> None:
         mock_open_cover.assert_awaited_once()
 
     with patch("teslajsonpy.car.TeslaCar.charge_port_door_close") as mock_close_cover:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_CLOSE_COVER,
             {ATTR_ENTITY_ID: "cover.my_model_s_charger_door"},
@@ -56,7 +56,7 @@ async def test_frunk(hass: HomeAssistant) -> None:
     await setup_platform(hass, COVER_DOMAIN)
 
     with patch("teslajsonpy.car.TeslaCar.toggle_frunk") as mock_toggle_frunk:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_OPEN_COVER,
             {ATTR_ENTITY_ID: "cover.my_model_s_frunk"},
@@ -70,7 +70,7 @@ async def test_trunk(hass: HomeAssistant) -> None:
     await setup_platform(hass, COVER_DOMAIN)
 
     with patch("teslajsonpy.car.TeslaCar.toggle_trunk") as mock_toggle_trunk:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_OPEN_COVER,
             {ATTR_ENTITY_ID: "cover.my_model_s_trunk"},
@@ -84,7 +84,7 @@ async def test_windows(hass: HomeAssistant) -> None:
     await setup_platform(hass, COVER_DOMAIN)
 
     with patch("teslajsonpy.car.TeslaCar.close_windows") as mock_close_cover:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_CLOSE_COVER,
             {ATTR_ENTITY_ID: "cover.my_model_s_windows"},
@@ -93,7 +93,7 @@ async def test_windows(hass: HomeAssistant) -> None:
         mock_close_cover.assert_not_awaited()
 
     with patch("teslajsonpy.car.TeslaCar.vent_windows") as mock_open_cover:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_OPEN_COVER,
             {ATTR_ENTITY_ID: "cover.my_model_s_windows"},
@@ -107,7 +107,7 @@ async def test_windows(hass: HomeAssistant) -> None:
     car_mock_data.VEHICLE_DATA["vehicle_state"]["rp_window"] = 1
 
     with patch("teslajsonpy.car.TeslaCar.vent_windows") as mock_open_cover:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_OPEN_COVER,
             {ATTR_ENTITY_ID: "cover.my_model_s_windows"},
@@ -116,7 +116,7 @@ async def test_windows(hass: HomeAssistant) -> None:
         mock_close_cover.assert_not_awaited()
 
     with patch("teslajsonpy.car.TeslaCar.close_windows") as mock_close_cover:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_CLOSE_COVER,
             {ATTR_ENTITY_ID: "cover.my_model_s_windows"},

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -24,7 +24,7 @@ async def test_car_door(hass: HomeAssistant) -> None:
     await setup_platform(hass, LOCK_DOMAIN)
 
     with patch("teslajsonpy.car.TeslaCar.unlock") as mock_unlock:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             LOCK_DOMAIN,
             SERVICE_UNLOCK,
             {ATTR_ENTITY_ID: "lock.my_model_s_doors"},
@@ -33,7 +33,7 @@ async def test_car_door(hass: HomeAssistant) -> None:
         mock_unlock.assert_awaited_once()
 
     with patch("teslajsonpy.car.TeslaCar.lock") as mock_unlock:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             LOCK_DOMAIN,
             SERVICE_LOCK,
             {ATTR_ENTITY_ID: "lock.my_model_s_doors"},
@@ -47,7 +47,7 @@ async def test_charge_port_latch(hass: HomeAssistant) -> None:
     await setup_platform(hass, LOCK_DOMAIN)
 
     with patch("teslajsonpy.car.TeslaCar.charge_port_door_open") as mock_unlock:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             LOCK_DOMAIN,
             SERVICE_UNLOCK,
             {ATTR_ENTITY_ID: "lock.my_model_s_charge_port_latch"},

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -53,7 +53,7 @@ async def test_set_charge_limit(hass: HomeAssistant) -> None:
     with patch(
         "teslajsonpy.car.TeslaCar.change_charge_limit"
     ) as mock_change_charge_limit:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             NUMBER_DOMAIN,
             "set_value",
             {ATTR_ENTITY_ID: "number.my_model_s_charge_limit", "value": 50.0},
@@ -84,7 +84,7 @@ async def test_set_charging_amps(hass: HomeAssistant) -> None:
     await setup_platform(hass, NUMBER_DOMAIN)
 
     with patch("teslajsonpy.car.TeslaCar.set_charging_amps") as mock_set_charging_amps:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             NUMBER_DOMAIN,
             "set_value",
             {ATTR_ENTITY_ID: "number.my_model_s_charging_amps", "value": 15.0},
@@ -113,7 +113,7 @@ async def test_set_backup_reserve(hass: HomeAssistant) -> None:
     with patch(
         "teslajsonpy.energy.PowerwallSite.set_reserve_percent"
     ) as mock_set_reserve_percent:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             NUMBER_DOMAIN,
             "set_value",
             {ATTR_ENTITY_ID: "number.battery_home_backup_reserve", "value": 20.0},

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -59,7 +59,7 @@ async def test_car_heated_seat_select(hass: HomeAssistant) -> None:
         "teslajsonpy.car.TeslaCar.remote_seat_heater_request"
     ) as mock_remote_seat_heater_request:
         # Test selecting "Off"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {ATTR_ENTITY_ID: "select.my_model_s_heated_seat_left", "option": "Off"},
@@ -67,7 +67,7 @@ async def test_car_heated_seat_select(hass: HomeAssistant) -> None:
         )
         mock_remote_seat_heater_request.assert_awaited_once_with(0, 0)
         # Test selecting "Low"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {ATTR_ENTITY_ID: "select.my_model_s_heated_seat_left", "option": "Low"},
@@ -75,7 +75,7 @@ async def test_car_heated_seat_select(hass: HomeAssistant) -> None:
         )
         mock_remote_seat_heater_request.assert_awaited_with(1, 0)
         # Test selecting "Medium"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {ATTR_ENTITY_ID: "select.my_model_s_heated_seat_left", "option": "Medium"},
@@ -83,7 +83,7 @@ async def test_car_heated_seat_select(hass: HomeAssistant) -> None:
         )
         mock_remote_seat_heater_request.assert_awaited_with(2, 0)
         # Test selecting "High"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {ATTR_ENTITY_ID: "select.my_model_s_heated_seat_left", "option": "High"},
@@ -95,7 +95,7 @@ async def test_car_heated_seat_select(hass: HomeAssistant) -> None:
         "teslajsonpy.car.TeslaCar.remote_auto_seat_climate_request"
     ) as mock_remote_auto_seat_climate_request:
         # Test selecting "Auto"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {ATTR_ENTITY_ID: "select.my_model_s_heated_seat_left", "option": "Auto"},
@@ -104,7 +104,7 @@ async def test_car_heated_seat_select(hass: HomeAssistant) -> None:
         mock_remote_auto_seat_climate_request.assert_awaited_once_with(1, True)
         # Test from "Auto" selection
         car_mock_data.VEHICLE_DATA["climate_state"]["auto_seat_climate_left"] = True
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {ATTR_ENTITY_ID: "select.my_model_s_heated_seat_left", "option": "Low"},
@@ -114,7 +114,7 @@ async def test_car_heated_seat_select(hass: HomeAssistant) -> None:
 
     with patch("teslajsonpy.car.TeslaCar.set_hvac_mode") as mock_set_hvac_mode:
         # Test climate_on check
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {ATTR_ENTITY_ID: "select.my_model_s_heated_seat_left", "option": "Low"},
@@ -131,7 +131,7 @@ async def test_cabin_overheat_protection(hass: HomeAssistant) -> None:
         "teslajsonpy.car.TeslaCar.set_cabin_overheat_protection"
     ) as mock_set_cabin_overheat_protection:
         # Test selecting "On"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
@@ -142,7 +142,7 @@ async def test_cabin_overheat_protection(hass: HomeAssistant) -> None:
         )
         mock_set_cabin_overheat_protection.assert_awaited_once_with("On")
         # Test selecting "Off"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
@@ -153,7 +153,7 @@ async def test_cabin_overheat_protection(hass: HomeAssistant) -> None:
         )
         mock_set_cabin_overheat_protection.assert_awaited_with("Off")
         # Test selecting "No A/C"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
@@ -173,7 +173,7 @@ async def test_grid_charging(hass: HomeAssistant) -> None:
         "teslajsonpy.energy.SolarPowerwallSite.set_grid_charging"
     ) as mock_set_grid_charging:
         # Test selecting "Yes"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
@@ -184,7 +184,7 @@ async def test_grid_charging(hass: HomeAssistant) -> None:
         )
         mock_set_grid_charging.assert_awaited_once_with(True)
         # Test selecting "No"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
@@ -204,7 +204,7 @@ async def test_energy_exports(hass: HomeAssistant) -> None:
         "teslajsonpy.energy.SolarPowerwallSite.set_export_rule"
     ) as mock_set_export_rule:
         # Test selecting "Solar"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
@@ -215,7 +215,7 @@ async def test_energy_exports(hass: HomeAssistant) -> None:
         )
         mock_set_export_rule.assert_awaited_once_with("pv_only")
         # Test selecting "Everything"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
@@ -235,7 +235,7 @@ async def test_operation_mode(hass: HomeAssistant) -> None:
         "teslajsonpy.energy.SolarPowerwallSite.set_operation_mode"
     ) as mock_set_operation_mode:
         # Test selecting "Self-Powered"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
@@ -246,7 +246,7 @@ async def test_operation_mode(hass: HomeAssistant) -> None:
         )
         mock_set_operation_mode.assert_awaited_once_with("self_consumption")
         # Test selecting "Time-Based Control"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
@@ -257,7 +257,7 @@ async def test_operation_mode(hass: HomeAssistant) -> None:
         )
         mock_set_operation_mode.assert_awaited_with("autonomous")
         # Test selecting "Backup"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
@@ -279,7 +279,7 @@ async def test_car_heated_steering_wheel_select(hass: HomeAssistant) -> None:
         "teslajsonpy.car.TeslaCar.set_heated_steering_wheel_level"
     ) as mock_set_heated_steering_wheel_level:
         # Test selecting "Off"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
@@ -290,7 +290,7 @@ async def test_car_heated_steering_wheel_select(hass: HomeAssistant) -> None:
         )
         mock_set_heated_steering_wheel_level.assert_awaited_once_with(0)
         # Test selecting "Low"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
@@ -301,7 +301,7 @@ async def test_car_heated_steering_wheel_select(hass: HomeAssistant) -> None:
         )
         mock_set_heated_steering_wheel_level.assert_awaited_with(1)
         # Test selecting "High"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
@@ -316,7 +316,7 @@ async def test_car_heated_steering_wheel_select(hass: HomeAssistant) -> None:
         "teslajsonpy.car.TeslaCar.remote_auto_steering_wheel_heat_climate_request"
     ) as mock_remote_auto_steering_wheel_heat_climate_request:
         # Test selecting "Auto"
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
@@ -330,7 +330,7 @@ async def test_car_heated_steering_wheel_select(hass: HomeAssistant) -> None:
         )
         # Test from "Auto" selection
         car_mock_data.VEHICLE_DATA["climate_state"]["auto_seat_climate_left"] = True
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {
@@ -343,7 +343,7 @@ async def test_car_heated_steering_wheel_select(hass: HomeAssistant) -> None:
 
     with patch("teslajsonpy.car.TeslaCar.set_hvac_mode") as mock_set_hvac_mode:
         # Test climate_on check
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -105,7 +105,7 @@ async def test_heated_steering(hass: HomeAssistant) -> None:
 #         "teslajsonpy.Controller.set_updates"
 #     ) as mock_controller_set_updates, patch("teslajsonpy.Controller.get_updates"):
 
-#         assert await hass.services.async_call(
+#         await hass.services.async_call(
 #             SWITCH_DOMAIN,
 #             SERVICE_TURN_ON,
 #             {ATTR_ENTITY_ID: "switch.my_model_s_polling"},
@@ -120,7 +120,7 @@ async def test_charger(hass: HomeAssistant) -> None:
 
     with patch("teslajsonpy.car.TeslaCar.start_charge") as mock_start_charge:
         # Test switch on
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
             {ATTR_ENTITY_ID: "switch.my_model_s_charger"},
@@ -130,7 +130,7 @@ async def test_charger(hass: HomeAssistant) -> None:
 
     with patch("teslajsonpy.car.TeslaCar.stop_charge") as mock_start_charge:
         # Test switch off
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_OFF,
             {ATTR_ENTITY_ID: "switch.my_model_s_charger"},
@@ -146,7 +146,7 @@ async def test_sentry_mode(hass: HomeAssistant) -> None:
 
     with patch("teslajsonpy.car.TeslaCar.set_sentry_mode") as mock_set_sentry_mode:
         # Test switch on
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
             {ATTR_ENTITY_ID: "switch.my_model_s_sentry_mode"},
@@ -154,7 +154,7 @@ async def test_sentry_mode(hass: HomeAssistant) -> None:
         )
         mock_set_sentry_mode.assert_awaited_once_with(True)
         # Test switch off
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_OFF,
             {ATTR_ENTITY_ID: "switch.my_model_s_sentry_mode"},
@@ -170,7 +170,7 @@ async def test_valet_mode(hass: HomeAssistant) -> None:
 
     with patch("teslajsonpy.car.TeslaCar.valet_mode") as mock_valet_mode:
         # Test switch on
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
             {ATTR_ENTITY_ID: "switch.my_model_s_valet_mode"},
@@ -178,7 +178,7 @@ async def test_valet_mode(hass: HomeAssistant) -> None:
         )
         mock_valet_mode.assert_awaited_once_with(True)
         # Test switch off
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_OFF,
             {ATTR_ENTITY_ID: "switch.my_model_s_valet_mode"},
@@ -189,14 +189,14 @@ async def test_valet_mode(hass: HomeAssistant) -> None:
     with patch("teslajsonpy.car.TeslaCar.valet_mode") as mock_pin_required:
         # Test pin required
         car_mock_data.VEHICLE_DATA["vehicle_state"]["valet_pin_needed"] = True
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
             {ATTR_ENTITY_ID: "switch.my_model_s_valet_mode"},
             blocking=True,
         )
         mock_pin_required.assert_not_awaited()
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_OFF,
             {ATTR_ENTITY_ID: "switch.my_model_s_valet_mode"},

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -102,7 +102,7 @@ async def test_status_available(hass: HomeAssistant) -> None:
     with patch(
         "teslajsonpy.car.TeslaCar.schedule_software_update"
     ) as mock_schedule_software_update:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             UPDATE_DOMAIN,
             "install",
             {ATTR_ENTITY_ID: "update.my_model_s_software_update"},
@@ -138,7 +138,7 @@ async def test_status_scheduled(hass: HomeAssistant) -> None:
     with patch(
         "teslajsonpy.car.TeslaCar.schedule_software_update"
     ) as mock_schedule_software_update:
-        assert await hass.services.async_call(
+        await hass.services.async_call(
             UPDATE_DOMAIN,
             "install",
             {ATTR_ENTITY_ID: "update.my_model_s_software_update"},


### PR DESCRIPTION
Fix the tests!

Most tests just had a broken `hass.services.async_call`.
`hass.services.async_call` no longer returns a boolean, as documented here:
https://developers.home-assistant.io/blog/2023/06/14/service-calls/
Fix: just don't look at the return value anymore.

However, some tests fail due to mismatch in mock data and teslajsonpy and/or extraction code in `sensor.py`.
I have fixed them by modifying the mock data.

Not sure if that is the correct approach. Are there recent examples of SolarPowerwallSite responses?