### PR TITLE
fix: Re-add usable_battery_level from mqtt

### DIFF
--- a/custom_components/tesla_custom/teslamate.py
+++ b/custom_components/tesla_custom/teslamate.py
@@ -141,6 +141,7 @@ MAP_CHARGE_STATE = {
     "rated_battery_range_km": ("battery_range", cast_km_to_miles),
     "est_battery_range_km": ("est_battery_range", cast_km_to_miles),
     "ideal_battery_range_km": ("ideal_battery_range", cast_km_to_miles),
+    "usable_battery_level": ("usable_battery_level", float),
     "charge_energy_added": ("charge_energy_added", float),
     "charger_actual_current": ("charger_actual_current", int),
     "charger_power": ("charger_power", int),


### PR DESCRIPTION
The last commit unfortunately removed the MQTT-sync for `usable_battery_level` by mistake. Re-add the line to sync `usable_battery_level` from Teslamate