### PR TITLE
chore: add issue form for car

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_car.yml
+++ b/.github/ISSUE_TEMPLATE/issue_car.yml
@@ -1,7 +1,7 @@
-name: Issue
+name: Telsa Car Issue
 description: Create a report to help us improve
-title: "Issue: "
-labels: ["triage"]
+title: "Car Issue: "
+labels: ["triage", "car"]
 body:
   - type: checkboxes
     attributes:
@@ -19,11 +19,27 @@ body:
         - Issues without configuration will be closed
       
   - type: input
-    id: version
+    id: version_hacs
     attributes:
       label: Version of the Tesla component
       description: You can find this under HACS -> Integrations -> Tesla. If you are not using the newest version, download and try that before opening an issue
       placeholder: ex. v3.19.3
+    validations:
+      required: true
+  - type: input
+    id: version_tesla
+    attributes:
+      label: Version of the Tesla car software 
+      description: Open the Tesla app -> Select car -> Scroll to bottom
+      placeholder: ex. 2023.44.1
+    validations:
+      required: true
+  - type: input
+    id: model_tesla
+    attributes:
+      label: Model
+      description: The model of the Tesla
+      placeholder: ex. Model 3
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/issue_car.yml
+++ b/.github/ISSUE_TEMPLATE/issue_car.yml
@@ -8,8 +8,8 @@ body:
       label: Is there an existing issue for this?
       description: Before you open a new issue, search through the existing issues to see if others have had the same problem.
       options:
-      - label: I have searched the existing issues
-        required: true
+        - label: I have searched the existing issues
+          required: true
   - type: markdown
     attributes:
       value: |
@@ -17,7 +17,7 @@ body:
         - Issues without a description (using the header is not good enough) will be closed.
         - Issues without debug logging will be closed.
         - Issues without configuration will be closed
-      
+
   - type: input
     id: version_hacs
     attributes:
@@ -29,7 +29,7 @@ body:
   - type: input
     id: version_tesla
     attributes:
-      label: Version of the Tesla car software 
+      label: Version of the Tesla car software
       description: Open the Tesla app -> Select car -> Scroll to bottom
       placeholder: ex. 2023.44.1
     validations:
@@ -48,14 +48,14 @@ body:
       description: A concise description of what you're experiencing.
     validations:
       required: true
-      
+
   - type: textarea
     attributes:
-      label: Expected Behavior 
+      label: Expected Behavior
       description: A concise description of what you expected to happen.
     validations:
       required: true
-  
+
   - type: textarea
     attributes:
       label: Debug logs
@@ -64,7 +64,7 @@ body:
         Your logs here
     validations:
       required: true
-  
+
   - type: textarea
     attributes:
       label: Anything else?

--- a/.github/ISSUE_TEMPLATE/issue_car.yml
+++ b/.github/ISSUE_TEMPLATE/issue_car.yml
@@ -16,7 +16,6 @@ body:
         Issues not containing the minimum requirements will be closed:
         - Issues without a description (using the header is not good enough) will be closed.
         - Issues without debug logging will be closed.
-        - Issues without configuration will be closed
 
   - type: input
     id: version_hacs
@@ -59,7 +58,8 @@ body:
   - type: textarea
     attributes:
       label: Debug logs
-      description: Enable the debug logs https://my.home-assistant.io/redirect/integration/?domain=tesla_custom & click `Enable debug logging`
+      description: Enable the debug logs ([In Home Assistant](https://my.home-assistant.io/redirect/integration/?domain=tesla_custom) & click `Enable debug logging`)
+      render: true
       placeholder: |
         Your logs here
     validations:

--- a/.github/ISSUE_TEMPLATE/issue_car.yml
+++ b/.github/ISSUE_TEMPLATE/issue_car.yml
@@ -6,9 +6,9 @@ body:
   - type: checkboxes
     attributes:
       label: Is there an existing issue for this?
-      description: Before you open a new issue, search through the existing issues to see if others have had the same problem.
+      description: Before you open a new issue, search through the existing open issues and closed issues to see if others have had the same problem.
       options:
-        - label: I have searched the existing issues
+        - label: I have searched both the existing open issues & recently closed issues and did not find a duplicate of this issue.
           required: true
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue_form.yml
+++ b/.github/ISSUE_TEMPLATE/issue_form.yml
@@ -1,0 +1,58 @@
+name: Issue
+description: Create a report to help us improve
+title: "Issue: "
+labels: ["triage"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Before you open a new issue, search through the existing issues to see if others have had the same problem.
+      options:
+      - label: I have searched the existing issues
+        required: true
+  - type: markdown
+    attributes:
+      value: |
+        Issues not containing the minimum requirements will be closed:
+        - Issues without a description (using the header is not good enough) will be closed.
+        - Issues without debug logging will be closed.
+        - Issues without configuration will be closed
+      
+  - type: input
+    id: version
+    attributes:
+      label: Version of the Tesla component
+      description: You can find this under HACS -> Integrations -> Tesla. If you are not using the newest version, download and try that before opening an issue
+      placeholder: ex. v3.19.3
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
+    validations:
+      required: true
+      
+  - type: textarea
+    attributes:
+      label: Expected Behavior 
+      description: A concise description of what you expected to happen.
+    validations:
+      required: true
+  
+  - type: textarea
+    attributes:
+      label: Debug logs
+      description: Enable the debug logs https://my.home-assistant.io/redirect/integration/?domain=tesla_custom & click `Enable debug logging`
+      placeholder: |
+        Your logs here
+    validations:
+      required: true
+  
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering
+    validations:
+      required: false


### PR DESCRIPTION
Here's an initial attempt at creating an issue form to get information from users using the current new issue template as the basis.

![image](https://github.com/alandtse/tesla/assets/26724777/eca0b8b2-6b9a-4de4-83fa-28cb2adf8b52)

I am in two minds if this should be a bug form rather than a general issue one, given the questions asked/input required?