### PR TITLE
fix: avoid blocking the event loop during import

### DIFF
--- a/custom_components/tesla_custom/manifest.json
+++ b/custom_components/tesla_custom/manifest.json
@@ -22,8 +22,8 @@
   "documentation": "https://github.com/alandtse/tesla/wiki",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/alandtse/tesla/issues",
+  "import_executor": true,
   "loggers": ["teslajsonpy"],
   "requirements": ["teslajsonpy==3.9.11"],
-  "import_executor": true,
   "version": "3.19.9"
 }

--- a/custom_components/tesla_custom/manifest.json
+++ b/custom_components/tesla_custom/manifest.json
@@ -20,8 +20,8 @@
     }
   ],
   "documentation": "https://github.com/alandtse/tesla/wiki",
-  "iot_class": "cloud_polling",
   "import_executor": true,
+  "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/alandtse/tesla/issues",
   "loggers": ["teslajsonpy"],
   "requirements": ["teslajsonpy==3.9.11"],

--- a/custom_components/tesla_custom/manifest.json
+++ b/custom_components/tesla_custom/manifest.json
@@ -21,8 +21,8 @@
   ],
   "documentation": "https://github.com/alandtse/tesla/wiki",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/alandtse/tesla/issues",
   "import_executor": true,
+  "issue_tracker": "https://github.com/alandtse/tesla/issues",
   "loggers": ["teslajsonpy"],
   "requirements": ["teslajsonpy==3.9.11"],
   "version": "3.19.9"

--- a/custom_components/tesla_custom/manifest.json
+++ b/custom_components/tesla_custom/manifest.json
@@ -24,5 +24,6 @@
   "issue_tracker": "https://github.com/alandtse/tesla/issues",
   "loggers": ["teslajsonpy"],
   "requirements": ["teslajsonpy==3.9.11"],
+  "import_executor": true,
   "version": "3.19.9"
 }


### PR DESCRIPTION
This option is new for 2024.3. Previously all integrations had to be imported in the event loop which would block the loop while it happened.

This option is safe to add for pre 2024.3 as it will do nothing.

This could be considered `pref` but not blocking the event loop is might always considered a fix