### PR TITLE
fix: set default client_id ownerapi

### DIFF
--- a/custom_components/tesla_custom/config_flow.py
+++ b/custom_components/tesla_custom/config_flow.py
@@ -279,7 +279,7 @@ async def validate_input(hass: core.HomeAssistant, data) -> dict:
         config[CONF_INCLUDE_ENERGYSITES] = data[CONF_INCLUDE_ENERGYSITES]
         config[CONF_API_PROXY_URL] = data.get(CONF_API_PROXY_URL)
         config[CONF_API_PROXY_CERT] = data.get(CONF_API_PROXY_CERT)
-        config[CONF_CLIENT_ID] = data.get(CONF_CLIENT_ID)
+        config[CONF_CLIENT_ID] = data.get(CONF_CLIENT_ID, "ownerapi")
 
     except IncompleteCredentials as ex:
         _LOGGER.error("Authentication error: %s %s", ex.message, ex)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -97,7 +97,7 @@ async def test_form(hass):
         "initial_setup": True,
         CONF_API_PROXY_URL: None,
         CONF_API_PROXY_CERT: None,
-        CONF_CLIENT_ID: None,
+        CONF_CLIENT_ID: "ownerapi",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -344,7 +344,7 @@ async def test_import(hass):
                 CONF_API_PROXY_ENABLE: False,
                 CONF_API_PROXY_CERT: None,
                 CONF_API_PROXY_URL: None,
-                CONF_CLIENT_ID: None,
+                CONF_CLIENT_ID: "ownerapi",
             },
         )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY


### PR DESCRIPTION
Client ID should be `ownerapi` for compatibility with old style.

Fixes #889 