### PR TITLE
chore: Add Fleet API warning

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_car.yml
+++ b/.github/ISSUE_TEMPLATE/issue_car.yml
@@ -1,6 +1,6 @@
 name: Telsa Car Issue
 description: Create a report to help us improve
-title: "Car Issue: "
+title: "Car: "
 labels: ["triage", "car"]
 body:
   - type: checkboxes
@@ -10,6 +10,14 @@ body:
       options:
         - label: I have searched both the existing open issues & recently closed issues and did not find a duplicate of this issue.
           required: true
+  - type: checkboxes
+    attributes:
+      label: I have read about the [Fleet API](https://github.com/alandtse/tesla?tab=readme-ov-file#tesla-fleet-api-proxy) and understand I may need to use it
+      description:  Unless you have a Pre-2021 Model S/X the Fleet API will need to be used for all other vehicles in the future.
+      options:
+        - label: I understand issues relating to read only commands will be auto closed if not using the Fleet API.
+          required: true
+          
   - type: markdown
     attributes:
       value: |
@@ -61,7 +69,7 @@ body:
       description: Enable the debug logs ([In Home Assistant](https://my.home-assistant.io/redirect/integration/?domain=tesla_custom) & click `Enable debug logging`)
       render: true
       placeholder: |
-        Your logs here
+        Your logs here, please follow the instructions above - https://my.home-assistant.io/redirect/integration/?domain=tesla_custom.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/issue_car.yml
+++ b/.github/ISSUE_TEMPLATE/issue_car.yml
@@ -13,11 +13,11 @@ body:
   - type: checkboxes
     attributes:
       label: I have read about the [Fleet API](https://github.com/alandtse/tesla?tab=readme-ov-file#tesla-fleet-api-proxy) and understand I may need to use it
-      description:  Unless you have a Pre-2021 Model S/X the Fleet API will need to be used for all other vehicles in the future.
+      description: Unless you have a Pre-2021 Model S/X the Fleet API will need to be used for all other vehicles in the future.
       options:
         - label: I understand issues relating to read only commands will be auto closed if not using the Fleet API.
           required: true
-          
+
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
Try and reduce API readonly issues being raised with non-fleet api by highlighting the information in the `readme.md`