### PR TITLE
docs: improve logging for SSL_CONTEXT

### DIFF
--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -144,7 +144,7 @@ async def async_setup_entry(hass, config_entry):
     if config.get(CONF_API_PROXY_CERT):
         try:
             SSL_CONTEXT.load_verify_locations(config[CONF_API_PROXY_CERT])
-            _LOGGER.debug(SSL_CONTEXT)
+            _LOGGER.debug("Trusting CA: %s", SSL_CONTEXT.get_ca_certs()[-1])
         except (FileNotFoundError, ssl.SSLError):
             _LOGGER.warning(
                 "Unable to load custom SSL certificate from %s",


### PR DESCRIPTION
This might help debugging some issues with unusual installations of API Proxy.

Previously the debug log looked like this:

> 2024-03-30 16:49:26.782 DEBUG (MainThread) [custom_components.tesla_custom] <ssl.SSLContext object at 0xffffaa55c4d0>

Now it looks like this:

> 2024-03-30 11:14:42.786 DEBUG (MainThread) [custom_components.tesla_custom] Trusting CA: {'subject': ((('commonName', 'c03d64a7-tesla-http-proxy'),),), 'issuer': ((('commonName', 'c03d64a7-tesla-http-proxy'),),), 'version': 3, 'serialNumber': '2431556855DA35772206E0D7305F10AA31A4119A', 'notBefore': 'Mar 24 01:43:47 2024 GMT', 'notAfter': 'Mar 22 01:43:47 2034 GMT'}