### PR TITLE
chore: Tidy up issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
+labels: enhancement
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATE/issue_car.yml
+++ b/.github/ISSUE_TEMPLATE/issue_car.yml
@@ -1,6 +1,5 @@
 name: Telsa Car Issue
 description: Create a report to help us improve
-title: "Car: "
 labels: ["triage", "car"]
 body:
   - type: checkboxes
@@ -12,8 +11,8 @@ body:
           required: true
   - type: checkboxes
     attributes:
-      label: I have read about the [Fleet API](https://github.com/alandtse/tesla?tab=readme-ov-file#tesla-fleet-api-proxy) and understand I may need to use it
-      description: Unless you have a Pre-2021 Model S/X the Fleet API will need to be used for all other vehicles in the future.
+      label: I have read about the Fleet API and understand I may need to use it
+      description: Unless you have a Pre-2021 Model S/X the [Fleet API](https://github.com/alandtse/tesla?tab=readme-ov-file#tesla-fleet-api-proxy) will need to be used for all other vehicles in the future.
       options:
         - label: I understand issues relating to read only commands will be auto closed if not using the Fleet API.
           required: true

--- a/.github/ISSUE_TEMPLATE/issue_powerwall.yml
+++ b/.github/ISSUE_TEMPLATE/issue_powerwall.yml
@@ -1,6 +1,5 @@
 name: Powerwall Issue
 description: Create a report to help us improve
-title: "Powerwall Issue: "
 labels: ["triage", "powerwall"]
 body:
   - type: checkboxes


### PR DESCRIPTION
Tweaks to make the issue templates nicer to use
- Fix link to Fleet API in `car` issue template
- Remove default titles, as this meant titles might not be set correctly & labels already describe if it's `car`, `powerwall`, etc
- Add `enhancement` label for `feature` issue