### PR TITLE
perf: avoid writing state if poll did not happen

### DIFF
--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -436,6 +436,7 @@ class TeslaDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER,
             name=DOMAIN,
             update_interval=update_interval,
+            always_update=False,
         )
 
     async def _async_update_data(self):

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Tesla",
   "hacs": "1.6.0",
-  "homeassistant": "2023.7.0",
+  "homeassistant": "2023.9.0",
   "zip_release": true,
   "filename": "tesla_custom.zip"
 }


### PR DESCRIPTION
#948 made me realize that the car data was being polled far less frequently than I thought as the underlying library was caching, but every time the coordinator fired, it would still callback all the listeners and write the state of all the entities which meant we ended up writing state every 10 seconds even if nothing has changed.

Since the data the coordinator returns can be compared with `__eq__`, enabling `always_update=False` will check if the data has changed and only fire the listeners if it has. This avoids **thousands** of entity writes per minute which was the bulk of the state writes on my HA instance.  

This reduced the number of calls to `async_write_ha_state` by 62% on my production HA instance!

related PR https://github.com/home-assistant/core/pull/97268