### PR TITLE
perf: only write state when data changes (#954)

### DIFF
--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -427,6 +427,7 @@ class TeslaDataUpdateCoordinator(DataUpdateCoordinator):
         self.update_vehicles = update_vehicles
         self._debounce_task = None
         self._last_update_time = None
+        self.last_controller_update_time: float | None = None
         self.assumed_state = True
 
         update_interval = timedelta(seconds=MIN_SCAN_INTERVAL)
@@ -477,8 +478,11 @@ class TeslaDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(f"Error communicating with API: {err}") from err
         else:
             if vin := self.vin:
+                self.last_controller_update_time = controller.get_last_update_time(
+                    vin=vin
+                )
                 self.assumed_state = not controller.is_car_online(vin=vin) and (
-                    controller.get_last_update_time(vin=vin)
+                    self.last_controller_update_time
                     - controller.get_last_wake_up_time(vin=vin)
                     > controller.update_interval
                 )


### PR DESCRIPTION
* perf: avoid writing state when the controller did not actually update

#948 made me realize that the car data was being polled far less frequently than I thought as the underlying library was caching, but every time the coordinator fired, it would still callback all the listeners and write the state of all the entities which meant we ended up writing state every 10 seconds even if nothing has changed.

Keep track of when the controller was last updated in each entity and if it has not changed, we skip the state write.

This reduced the number of calls to `async_write_ha_state` by 62% on my production HA instance!

* fix async_added_to_hass was being overridden and forgot to remove in pr