### PR TITLE
fix: update coordinator update time when receiving data from mqtt

### DIFF
--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -427,7 +427,7 @@ class TeslaDataUpdateCoordinator(DataUpdateCoordinator):
         self.update_vehicles = update_vehicles
         self._debounce_task = None
         self._last_update_time = None
-        self.last_controller_update_time: float | None = None
+        self.last_update_time: float | None = None
         self.assumed_state = True
 
         update_interval = timedelta(seconds=MIN_SCAN_INTERVAL)
@@ -478,12 +478,9 @@ class TeslaDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(f"Error communicating with API: {err}") from err
         else:
             if vin := self.vin:
-                self.last_controller_update_time = controller.get_last_update_time(
-                    vin=vin
-                )
+                self.last_update_time = controller.get_last_update_time(vin=vin)
                 self.assumed_state = not controller.is_car_online(vin=vin) and (
-                    self.last_controller_update_time
-                    - controller.get_last_wake_up_time(vin=vin)
+                    self.last_update_time - controller.get_last_wake_up_time(vin=vin)
                     > controller.update_interval
                 )
         return data

--- a/custom_components/tesla_custom/base.py
+++ b/custom_components/tesla_custom/base.py
@@ -57,21 +57,21 @@ class TeslaCarEntity(TeslaBaseEntity):
             sw_version=car.car_version,
         )
         self._last_update_success: bool | None = None
-        self._last_controller_update_time: float | None = None
+        self._last_update_time: float | None = None
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         prev_last_update_success = self._last_update_success
-        prev_last_controller_update_time = self._last_controller_update_time
+        prev_last_update_time = self._last_update_time
         coordinator = self.coordinator
         current_last_update_success = coordinator.last_update_success
-        current_last_controller_update_time = coordinator.last_controller_update_time
+        current_last_update_time = coordinator.last_update_time
         self._last_update_success = current_last_update_success
-        self._last_controller_update_time = current_last_controller_update_time
+        self._last_update_time = current_last_update_time
         if (
             prev_last_update_success == current_last_update_success
-            and prev_last_controller_update_time == current_last_controller_update_time
+            and prev_last_update_time == current_last_update_time
         ):
             # If there was no change in the last update success or time,
             # avoid writing state to prevent unnecessary entity updates.

--- a/custom_components/tesla_custom/teslamate.py
+++ b/custom_components/tesla_custom/teslamate.py
@@ -6,6 +6,7 @@ with the latest data.
 
 import asyncio
 import logging
+import time
 from typing import TYPE_CHECKING
 
 from homeassistant.components.mqtt import mqtt_config_entry_enabled
@@ -155,7 +156,7 @@ class TeslaMate:
     def __init__(
         self,
         hass: HomeAssistant,
-        coordinators: list["TeslaDataUpdateCoordinator"],
+        coordinators: dict[str, "TeslaDataUpdateCoordinator"],
         cars: dict[str, TeslaCar],
     ) -> None:
         """Init Class."""
@@ -372,6 +373,8 @@ class TeslaMate:
             # Nothing matched. Return without updating listeners.
             return
 
+        coordinator.last_update_time = round(time.time())
+        coordinator.assumed_state = False
         coordinator.async_update_listeners_debounced()
 
     def update_charging_state(self, car: TeslaCar, val: str):


### PR DESCRIPTION
Note that I don't use mqtt so I don't have a way to test this.  I was only able to test that it didn't regress the incoming data from the coordinator polling.



fixes #986
