### PR TITLE
feat: add climate preset icons

### DIFF
--- a/custom_components/tesla_custom/climate.py
+++ b/custom_components/tesla_custom/climate.py
@@ -50,6 +50,10 @@ class TeslaCarClimate(TeslaCarEntity, ClimateEntity):
     _attr_fan_modes = ["Off", "Bioweapon Mode"]
 
     @property
+    def translation_key(self):
+        return "car_climate"
+
+    @property
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode.
 

--- a/custom_components/tesla_custom/climate.py
+++ b/custom_components/tesla_custom/climate.py
@@ -18,9 +18,9 @@ _LOGGER = logging.getLogger(__name__)
 
 
 KEEPER_MAP = {
-    "Keep On": 1,
-    "Dog Mode": 2,
-    "Camp Mode": 3,
+    "keep": 1,
+    "dog": 2,
+    "camp": 3,
 }
 
 
@@ -46,8 +46,8 @@ class TeslaCarClimate(TeslaCarEntity, ClimateEntity):
         | ClimateEntityFeature.FAN_MODE
     )
     _attr_hvac_modes = [HVACMode.HEAT_COOL, HVACMode.OFF]
-    _attr_preset_modes = ["Normal", "Defrost", "Keep On", "Dog Mode", "Camp Mode"]
-    _attr_fan_modes = ["Off", "Bioweapon Mode"]
+    _attr_preset_modes = ["normal", "defrost", "keep", "dog", "camp"]
+    _attr_fan_modes = ["off", "bioweapon"]
 
     @property
     def translation_key(self):
@@ -125,21 +125,21 @@ class TeslaCarClimate(TeslaCarEntity, ClimateEntity):
         Requires SUPPORT_PRESET_MODE.
         """
         if self._car.defrost_mode == 2:
-            return "Defrost"
+            return "defrost"
         if self._car.climate_keeper_mode == "dog":
-            return "Dog Mode"
+            return "dog"
         if self._car.climate_keeper_mode == "camp":
-            return "Camp Mode"
+            return "camp"
         if self._car.climate_keeper_mode == "on":
-            return "Keep On"
+            return "keep"
 
-        return "Normal"
+        return "normal"
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         _LOGGER.debug("%s: Setting preset_mode to: %s", self.name, preset_mode)
 
-        if preset_mode == "Normal":
+        if preset_mode == "normal":
             # If setting Normal, we need to check Defrost And Keep modes.
             if self._car.defrost_mode != 0:
                 await self._car.set_max_defrost(0)
@@ -147,7 +147,7 @@ class TeslaCarClimate(TeslaCarEntity, ClimateEntity):
             if self._car.climate_keeper_mode != 0:
                 await self._car.set_climate_keeper_mode(0)
 
-        elif preset_mode == "Defrost":
+        elif preset_mode == "defrost":
             await self._car.set_max_defrost(2)
 
         else:
@@ -162,12 +162,12 @@ class TeslaCarClimate(TeslaCarEntity, ClimateEntity):
         Requires SUPPORT_FAN_MODE.
         """
         if self._car.bioweapon_mode:
-            return "Bioweapon Mode"
+            return "bioweapon"
 
-        return "Off"
+        return "off"
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode as bioweapon mode."""
         _LOGGER.debug("%s: Setting fan_mode to: %s", self.name, fan_mode)
 
-        await self._car.set_bioweapon_mode(fan_mode == "Bioweapon Mode")
+        await self._car.set_bioweapon_mode(fan_mode == "bioweapon")

--- a/custom_components/tesla_custom/icons.json
+++ b/custom_components/tesla_custom/icons.json
@@ -5,17 +5,17 @@
         "state_attributes": {
           "fan_mode": {
             "state": {
-              "Bioweapon Mode": "mdi:biohazard",
-              "Off": "mdi:power"
+              "bioweapon": "mdi:biohazard",
+              "off": "mdi:power"
             }
           },
           "preset_mode": {
             "state": {
-              "Normal": "mdi:fan",
-              "Defrost": "mdi:car-defrost-rear",
-              "Keep On": "mdi:infinity",
-              "Dog Mode": "mdi:dog",
-              "Camp Mode": "mdi:tent"
+              "normal": "mdi:fan",
+              "defrost": "mdi:car-defrost-rear",
+              "keep": "mdi:infinity",
+              "dog": "mdi:dog",
+              "camp": "mdi:tent"
             }
           }
         }

--- a/custom_components/tesla_custom/icons.json
+++ b/custom_components/tesla_custom/icons.json
@@ -1,0 +1,25 @@
+{
+  "entity": {
+    "climate": {
+      "car_climate": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "Bioweapon Mode": "mdi:biohazard",
+              "Off": "mdi:power"
+            }
+          },
+          "preset_mode": {
+            "state": {
+              "Normal": "mdi:fan",
+              "Defrost": "mdi:car-defrost-rear",
+              "Keep On": "mdi:infinity",
+              "Dog Mode": "mdi:dog",
+              "Camp Mode": "mdi:tent"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/tesla_custom/strings.json
+++ b/custom_components/tesla_custom/strings.json
@@ -82,5 +82,28 @@
         }
       }
     }
+  },
+  "entity": {
+    "climate": {
+      "car_climate": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "bioweapon":"Bioweapon Mode",
+              "off": "Normal"
+            }
+          },
+          "preset_mode": {
+            "state": {
+              "normal": "Normal",
+              "defrost": "Defrost",
+              "keep": "Keep On",
+              "dog": "Dog Mode",
+              "camp": "Camp Mode"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/tesla_custom/strings.json
+++ b/custom_components/tesla_custom/strings.json
@@ -89,7 +89,7 @@
         "state_attributes": {
           "fan_mode": {
             "state": {
-              "bioweapon":"Bioweapon Mode",
+              "bioweapon": "Bioweapon Mode",
               "off": "Normal"
             }
           },

--- a/custom_components/tesla_custom/translations/en.json
+++ b/custom_components/tesla_custom/translations/en.json
@@ -82,5 +82,28 @@
         }
       }
     }
+  },
+  "entity": {
+    "climate": {
+      "car_climate": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "bioweapon":"Bioweapon Mode",
+              "off": "Normal"
+            }
+          },
+          "preset_mode": {
+            "state": {
+              "normal": "Normal",
+              "defrost": "Defrost",
+              "keep": "Keep On",
+              "dog": "Dog Mode",
+              "camp": "Camp Mode"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/tesla_custom/translations/en.json
+++ b/custom_components/tesla_custom/translations/en.json
@@ -89,7 +89,7 @@
         "state_attributes": {
           "fan_mode": {
             "state": {
-              "bioweapon":"Bioweapon Mode",
+              "bioweapon": "Bioweapon Mode",
               "off": "Normal"
             }
           },

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -92,7 +92,7 @@ async def test_set_fan_mode(hass: HomeAssistant) -> None:
             "set_fan_mode",
             {
                 ATTR_ENTITY_ID: DEVICE_ID,
-                "fan_mode": "Bioweapon Mode",
+                "fan_mode": "bioweapon",
             },
             blocking=True,
         )
@@ -113,7 +113,7 @@ async def test_set_preset_mode(hass: HomeAssistant) -> None:
             "set_preset_mode",
             {
                 ATTR_ENTITY_ID: DEVICE_ID,
-                "preset_mode": "Normal",
+                "preset_mode": "normal",
             },
             blocking=True,
         )
@@ -131,7 +131,7 @@ async def test_set_preset_mode(hass: HomeAssistant) -> None:
             "set_preset_mode",
             {
                 ATTR_ENTITY_ID: DEVICE_ID,
-                "preset_mode": "Normal",
+                "preset_mode": "normal",
             },
             blocking=True,
         )
@@ -144,7 +144,7 @@ async def test_set_preset_mode(hass: HomeAssistant) -> None:
             "set_preset_mode",
             {
                 ATTR_ENTITY_ID: DEVICE_ID,
-                "preset_mode": "Defrost",
+                "preset_mode": "defrost",
             },
             blocking=True,
         )
@@ -159,7 +159,7 @@ async def test_set_preset_mode(hass: HomeAssistant) -> None:
             "set_preset_mode",
             {
                 ATTR_ENTITY_ID: DEVICE_ID,
-                "preset_mode": "Dog Mode",
+                "preset_mode": "dog",
             },
             blocking=True,
         )


### PR DESCRIPTION
Added icons for climate preset modes and fan modes

***Breaking Changes***
strings.json and icons.json must be used for adding icons to climate preset and fan modes. Translation keys in these files can only consist of lowercase letters, numbers, and underscore.

1. Preset modes has to be renamed to ["normal", "defrost", "keep", "dog", "camp"], and 
2. Fan modes has to be renamed to ["off", "bioweapon"].

Please update your scripts and automations after this update.

Fixes issue [725](https://github.com/alandtse/tesla/issues/725)