### PR TITLE
fix: Uncaught exception when path_vars is not provided in action API

### DIFF
--- a/custom_components/tesla_custom/services.py
+++ b/custom_components/tesla_custom/services.py
@@ -5,11 +5,11 @@ SPDX-License-Identifier: Apache-2.0
 
 import logging
 
-import voluptuous as vol
 from homeassistant.const import ATTR_COMMAND, CONF_EMAIL, CONF_SCAN_INTERVAL
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from teslajsonpy import Controller
+import voluptuous as vol
 
 from .const import (
     ATTR_PARAMETERS,

--- a/custom_components/tesla_custom/services.py
+++ b/custom_components/tesla_custom/services.py
@@ -5,11 +5,11 @@ SPDX-License-Identifier: Apache-2.0
 
 import logging
 
+import voluptuous as vol
 from homeassistant.const import ATTR_COMMAND, CONF_EMAIL, CONF_SCAN_INTERVAL
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from teslajsonpy import Controller
-import voluptuous as vol
 
 from .const import (
     ATTR_PARAMETERS,
@@ -112,7 +112,7 @@ def async_setup_services(hass) -> None:
             command,
             parameters,
         )
-        path_vars = parameters.pop(ATTR_PATH_VARS)
+        path_vars = parameters.pop(ATTR_PATH_VARS, {})
         response = await controller.api(name=command, path_vars=path_vars, **parameters)
         return response
 


### PR DESCRIPTION
path_vars is not required for every action api call and is not enforced to be required. But when not provided it results in an uncaught exception.
This fix just ensures that if path_vars is not provided no exception occurs by providing as default an empty dictionary,