### PR TITLE
fix: car never reverting back from 'charging' when using Teslamate

### DIFF
--- a/custom_components/tesla_custom/teslamate.py
+++ b/custom_components/tesla_custom/teslamate.py
@@ -30,10 +30,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-CHARGING_STATE_CHARGING = "Charging"
-CHARGING_STATE_STOPPED = "Stopped"
-
-
 def is_car_state_charging(car_state: str) -> bool:
     """Check if car_state is charging."""
     return car_state == "charging"
@@ -79,31 +75,6 @@ def cast_speed(speed: int) -> int:
     return int(speed_miles)
 
 
-def cast_plugged_in(val: str, car: TeslaCar) -> str:
-    """Casts new car plugged_in.
-
-    When receiving a new value here, we also need to check the
-    car state to see if it is charging or not before returning
-    a value to be set as 'charging_state'
-    """
-    plugged_in = cast_bool(val)
-
-    logger.debug(
-        "Casting plugged_in. Current state: '%s', plugged_in: '%s'",
-        car.state,
-        plugged_in,
-    )
-
-    if plugged_in:
-        return (
-            CHARGING_STATE_CHARGING
-            if is_car_state_charging(car.state)
-            else CHARGING_STATE_STOPPED
-        )
-
-    return "Disconnected"
-
-
 MAP_DRIVE_STATE = {
     "latitude": ("latitude", float),
     "longitude": ("longitude", float),
@@ -147,6 +118,7 @@ MAP_CHARGE_STATE = {
     "charge_port_door_open": ("charge_port_door_open", cast_bool),
     "charge_current_request": ("charge_current_request", int),
     "charge_current_request_max": ("charge_current_request_max", int),
+    "charging_state": ("charging_state", str),
 }
 
 
@@ -361,17 +333,8 @@ class TeslaMate:
             attr, cast = MAP_CHARGE_STATE[mqtt_attr]
             self.update_car_state(car, "charge_state", attr, cast(msg.payload))
 
-        elif mqtt_attr == "plugged_in":
-            self.update_charging_state(car, cast_plugged_in(msg.payload, car))
-
         elif mqtt_attr == "state":
             state = msg.payload
-
-            if is_car_state_charging(state):
-                self.update_charging_state(car, CHARGING_STATE_CHARGING)
-            else:
-                self.update_charging_state(car, CHARGING_STATE_STOPPED)
-
             self.update_car_state(car, None, "state", state)
 
         else:


### PR DESCRIPTION
Observe `charging_state` topic directly to update charging state of car when using Teslamate.

Fixes #1108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Charging status now updates directly from the charging state attribute for more reliable and timely information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->