### PR TITLE
fix: Add try-catch logic around powerwall reserve update

### DIFF
--- a/custom_components/tesla_custom/number.py
+++ b/custom_components/tesla_custom/number.py
@@ -122,8 +122,13 @@ class TeslaEnergyBackupReserve(TeslaEnergyEntity, NumberEntity):
 
     async def async_set_native_value(self, value: int) -> None:
         """Update backup reserve percentage."""
-        await self._energysite.set_reserve_percent(value)
-        self.async_write_ha_state()
+        try:
+            await self._energysite.set_reserve_percent(value)
+        except:
+            # Hack to stop exception blocking automation until teslajsonpy is updated
+            pass
+        finally:
+            self.async_write_ha_state()
 
     @property
     def native_value(self) -> int:


### PR DESCRIPTION
Attempts to hack-fix #1125 until teslajsonpy is updated to address API changes.

Currently the call to Tesla to update the Powerwall reserve succeeds but it no longer contains a `code` element and as the teslajsonpy expects this it exceptions which bubbles up and causes automations using this to error out (when in reality it has succeeded). There is an [issue raised to address](https://github.com/zabuldon/teslajsonpy/issues/486) this but in the mean time this hack fix should unblock this repo & can be reverted (or improved) once the dependency is sorted out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when setting backup reserve values by handling errors silently, ensuring Home Assistant state updates continue even if an error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->