### PR TITLE
fix: ignore stale TeslaMate VIN mappings

### DIFF
--- a/custom_components/tesla_custom/teslamate.py
+++ b/custom_components/tesla_custom/teslamate.py
@@ -212,20 +212,21 @@ class TeslaMate:
 
         await self.async_load()
 
-        found_vin = None
-
         car_map = self._data.get("car_map", {})
         for vin, tm_id in car_map.items():
-            if tm_id == teslamate_id:
-                found_vin = vin
-                break
+            if tm_id != teslamate_id:
+                continue
 
-        if found_vin is None:
-            return None
+            if car := self.cars.get(vin):
+                return car
 
-        car = self.cars.get(found_vin)
+            logger.debug(
+                "TeslaMate_id %s is mapped to stale VIN %s that is not loaded",
+                teslamate_id,
+                vin,
+            )
 
-        return car
+        return None
 
     async def enable(self, enable=True):
         """Start Listening to MQTT topics."""

--- a/tests/test_teslamate.py
+++ b/tests/test_teslamate.py
@@ -1,0 +1,28 @@
+"""Tests for TeslaMate MQTT support."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.tesla_custom.teslamate import TeslaMate
+
+from .mock_data import car as car_mock_data
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_get_car_from_id_skips_stale_vin_mapping() -> None:
+    """Test stale VIN mappings do not block active TeslaMate car mappings."""
+    active_car = SimpleNamespace(vin=car_mock_data.VIN)
+    teslamate = object.__new__(TeslaMate)
+    teslamate.cars = {car_mock_data.VIN: active_car}
+    teslamate._data = {
+        "car_map": {
+            "stale-vin": "1",
+            car_mock_data.VIN: "1",
+        }
+    }
+    teslamate.async_load = AsyncMock()
+
+    assert await teslamate.get_car_from_id("1") is active_car


### PR DESCRIPTION
## Summary
- Fix TeslaMate MQTT car-id lookup so stale VIN mappings do not block the active loaded VIN for the same TeslaMate id
- Continue checking other VIN mappings when a mapped VIN is not loaded
- Add regression coverage for stale VIN mappings appearing before the active VIN

This fixes the integration's TeslaMate MQTT consumer when multiple stored VIN mappings point at the same TeslaMate id. TeslaMate itself is publishing retained MQTT messages correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed car lookup to properly skip stale vehicle mappings and identify the correct vehicle.

* **Tests**
  * Added test coverage for handling stale vehicle mappings in car identification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/tesla/pull/1187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->