### PR TITLE
test: make cooling seat select test independent of execution order

### DIFF
--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -134,6 +134,11 @@ async def test_car_cooling_seat_select(hass: HomeAssistant) -> None:
     # Test cars with cooling/heated seats
     del car_mock_data.VEHICLE_DATA["vehicle_config"]["has_seat_cooling"]
     car_mock_data.VEHICLE_DATA["vehicle_config"]["has_seat_cooling"] = True
+    # The "Off" assertion below relies on the seat being in auto mode so that
+    # turning off issues a heater request. Set it explicitly rather than
+    # inheriting the leaked global state from test_car_heated_seat_select, which
+    # is not guaranteed to run first under pytest-xdist (-n auto).
+    car_mock_data.VEHICLE_DATA["climate_state"]["auto_seat_climate_left"] = True
 
     with patch(
         "teslajsonpy.car.TeslaCar.remote_seat_heater_request"


### PR DESCRIPTION
## Summary

`tests/test_select.py::test_car_cooling_seat_select` is a latent order-dependent test. It relies on global mock state leaked from a sibling test, which makes it fail intermittently under `pytest-xdist` (`-n auto`, used in CI) and always fail when run in isolation.

This is pre-existing test debt, split out from #1192 (which exposed it by adding a new test file that shifted xdist's work distribution).

## Root cause

- `test_car_heated_seat_select` sets `car_mock_data.VEHICLE_DATA["climate_state"]["auto_seat_climate_left"] = True` on the **shared module-level** mock dict.
- `test_car_cooling_seat_select`'s `"Off"` assertion only reaches `remote_seat_heater_request(0, 0)` via the auto-seat branch in `select.py`, which requires that flag to be `True`.
- CI runs `pytest -n auto`, which distributes tests across worker **processes** by load, not by file order. The cooling test can land on a worker where the heated test never ran → flag unset → `"remote_seat_heater_request awaited 0 times"`.

Verified locally:
- `test_car_cooling_seat_select` alone → **fails**
- `heated → cooling` → **passes**
- full suite `-n auto` → reproduced the failure; **fixed** after this change (108 passed).

## Fix

Set `auto_seat_climate_left = True` explicitly at the start of `test_car_cooling_seat_select` so it no longer depends on sibling-test ordering. No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability for the heated/cooling seat select feature to ensure consistent results across test execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->