### PR TITLE
chore: release 2026-06-07

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
       - id: commitizen
         stages: ["commit-msg"]
     repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.11.2
+    rev: v4.16.3
   # --- Linters ---
   - hooks:
       - id: dockerfile_lint
@@ -80,7 +80,7 @@ repos:
           - --configfile=tests/bandit.yaml
         files: ^(tests)/.+\.py$
   - repo: https://github.com/PyCQA/isort
-    rev: 7.0.0
+    rev: 9.0.0a3
     hooks:
       - id: isort
   #  - repo: local

--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -9,7 +9,7 @@ import ssl
 from typing import Any
 
 import async_timeout
-from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
     CONF_CLIENT_ID,
@@ -19,9 +19,9 @@ from homeassistant.const import (
     CONF_USERNAME,
     EVENT_HOMEASSISTANT_CLOSE,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.httpx_client import SERVER_SOFTWARE, USER_AGENT
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -381,6 +381,32 @@ async def async_unload_entry(hass, config_entry) -> bool:
         return True
 
     return False
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Remove a tesla_custom config entry from a device.
+
+    Allow removal only for devices that are no longer provided by the
+    integration (e.g. a vehicle that was removed from the Tesla account). The
+    live car(s) and energy site(s) are protected from deletion. Removal is
+    refused while the entry is not loaded, since we cannot then confirm what is
+    currently provided.
+    """
+    # Imported lazily to avoid a circular import: base imports
+    # TeslaDataUpdateCoordinator from this module at top level.
+    from .base import device_identifier
+
+    entry_data = hass.data.get(DOMAIN, {}).get(config_entry.entry_id)
+    if not entry_data:
+        return False
+    provided = {
+        device_identifier(tesla_device)
+        for tesla_device in list((entry_data.get("cars") or {}).values())
+        + list((entry_data.get("energysites") or {}).values())
+    }
+    return not device_entry.identifiers.intersection(provided)
 
 
 async def update_listener(hass, config_entry):

--- a/custom_components/tesla_custom/base.py
+++ b/custom_components/tesla_custom/base.py
@@ -12,6 +12,21 @@ from . import TeslaDataUpdateCoordinator
 from .const import ATTRIBUTION, DOMAIN
 
 
+def device_identifier(tesla_device: TeslaCar | EnergySite) -> tuple[str, int]:
+    """Return the (DOMAIN, id) device-registry identifier for a Tesla device.
+
+    Centralizes device identity so device registration (``device_info``) and
+    device removal (``async_remove_config_entry_device``) cannot drift apart.
+    Cars are identified by ``car.id``; energy sites by
+    ``energysite.energysite_id``. Note Home Assistant types identifiers as
+    ``tuple[str, str]``, but the integer ids are kept here so existing
+    registered devices are not migrated.
+    """
+    if isinstance(tesla_device, EnergySite):
+        return (DOMAIN, tesla_device.energysite_id)
+    return (DOMAIN, tesla_device.id)
+
+
 class TeslaBaseEntity(CoordinatorEntity[TeslaDataUpdateCoordinator]):
     """Representation of a Tesla device."""
 
@@ -52,7 +67,7 @@ class TeslaCarEntity(TeslaBaseEntity):
             else f"Tesla Model {str(vin[3]).upper()}"
         )
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, car.id)},
+            identifiers={device_identifier(car)},
             name=vehicle_name,
             manufacturer="Tesla",
             model=car.car_type,
@@ -126,7 +141,7 @@ class TeslaEnergyEntity(TeslaBaseEntity):
             # Non-Powerwall sites do not provide version info
             sw_version = "Unavailable"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, energysite_id)},
+            identifiers={device_identifier(energysite)},
             manufacturer="Tesla",
             model=energysite.resource_type.title(),
             name=energysite.site_name,

--- a/custom_components/tesla_custom/teslamate.py
+++ b/custom_components/tesla_custom/teslamate.py
@@ -212,20 +212,21 @@ class TeslaMate:
 
         await self.async_load()
 
-        found_vin = None
-
         car_map = self._data.get("car_map", {})
         for vin, tm_id in car_map.items():
-            if tm_id == teslamate_id:
-                found_vin = vin
-                break
+            if tm_id != teslamate_id:
+                continue
 
-        if found_vin is None:
-            return None
+            if car := self.cars.get(vin):
+                return car
 
-        car = self.cars.get(found_vin)
+            logger.debug(
+                "TeslaMate_id %s is mapped to stale VIN %s that is not loaded",
+                teslamate_id,
+                vin,
+            )
 
-        return car
+        return None
 
     async def enable(self, enable=True):
         """Start Listening to MQTT topics."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,217 @@
+"""Tests for the Tesla integration setup and device removal."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+import pytest
+from teslajsonpy.car import TeslaCar
+from teslajsonpy.energy import SolarPowerwallSite, SolarSite
+
+from custom_components.tesla_custom import async_remove_config_entry_device
+from custom_components.tesla_custom.base import device_identifier
+from custom_components.tesla_custom.const import DOMAIN
+
+from .common import setup_platform
+from .const import TEST_USERNAME
+from .mock_data import car as car_mock_data, energysite as energysite_mock_data
+
+# Mock data ids used across the helpers below.
+CAR_ID = 12345678901234567  # car_mock_data.VEHICLE["id"]
+SOLAR_SITE_ID = 12345
+BATTERY_SITE_ID = 67890
+
+
+def _make_car() -> TeslaCar:
+    """Return a TeslaCar built from the shared mock data."""
+    return TeslaCar(
+        car_mock_data.VEHICLE,
+        MagicMock(),
+        car_mock_data.VEHICLE_DATA,
+    )
+
+
+def _make_solar_site() -> SolarSite:
+    """Return a SolarSite built from the shared mock data."""
+    return SolarSite(
+        MagicMock(),
+        energysite_mock_data.ENERGYSITE_SOLAR,
+        energysite_mock_data.SITE_CONFIG_SOLAR,
+        energysite_mock_data.SITE_DATA,
+    )
+
+
+def _make_battery_site() -> SolarPowerwallSite:
+    """Return a SolarPowerwallSite built from the shared mock data."""
+    return SolarPowerwallSite(
+        MagicMock(),
+        energysite_mock_data.ENERGYSITE_BATTERY,
+        energysite_mock_data.SITE_CONFIG_POWERWALL,
+        energysite_mock_data.BATTERY_DATA,
+        energysite_mock_data.BATTERY_SUMMARY,
+    )
+
+
+def _device_entry(*identifiers) -> dr.DeviceEntry:
+    """Build a minimal DeviceEntry-like object exposing only identifiers."""
+    entry = MagicMock(spec=dr.DeviceEntry)
+    entry.identifiers = set(identifiers)
+    return entry
+
+
+def _config_entry(entry_id: str = "test_entry") -> ConfigEntry:
+    """Build a minimal ConfigEntry-like object exposing only entry_id."""
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = entry_id
+    return entry
+
+
+def test_device_identifier_discriminates_by_type() -> None:
+    """device_identifier uses car.id for cars and energysite_id for sites."""
+    car = _make_car()
+    solar = _make_solar_site()
+    battery = _make_battery_site()
+
+    assert device_identifier(car) == (DOMAIN, car.id)
+    assert device_identifier(solar) == (DOMAIN, SOLAR_SITE_ID)
+    assert device_identifier(battery) == (DOMAIN, BATTERY_SITE_ID)
+    # Energy sites must not be identified by car-style ``id``.
+    assert device_identifier(solar)[1] == solar.energysite_id
+    assert device_identifier(battery)[1] == battery.energysite_id
+
+
+def _entry_data():
+    """Return an entry_data dict shaped like hass.data[DOMAIN][entry_id]."""
+    return {
+        "cars": {car_mock_data.VIN: _make_car()},
+        "energysites": {
+            SOLAR_SITE_ID: _make_solar_site(),
+            BATTERY_SITE_ID: _make_battery_site(),
+        },
+    }
+
+
+def _hass_with_entry(entry_id: str = "test_entry"):
+    """Return a MagicMock hass whose data holds a loaded entry."""
+    hass = MagicMock(spec=HomeAssistant)
+    hass.data = {DOMAIN: {entry_id: _entry_data()}}
+    return hass
+
+
+async def test_remove_protects_live_car() -> None:
+    """A device matching a live car must not be removable."""
+    hass = _hass_with_entry()
+    device = _device_entry((DOMAIN, CAR_ID))
+    assert (
+        await async_remove_config_entry_device(hass, _config_entry(), device) is False
+    )
+
+
+async def test_remove_protects_live_energy_site() -> None:
+    """A device matching a live energy site must not be removable."""
+    hass = _hass_with_entry()
+    for site_id in (SOLAR_SITE_ID, BATTERY_SITE_ID):
+        device = _device_entry((DOMAIN, site_id))
+        assert (
+            await async_remove_config_entry_device(hass, _config_entry(), device)
+            is False
+        )
+
+
+async def test_remove_allows_orphan_device() -> None:
+    """A device no longer provided by the integration is removable."""
+    hass = _hass_with_entry()
+    device = _device_entry((DOMAIN, 99999999999))
+    assert await async_remove_config_entry_device(hass, _config_entry(), device) is True
+
+
+async def test_remove_refuses_when_entry_not_loaded() -> None:
+    """Removal must be refused while the config entry is not loaded."""
+    hass = MagicMock(spec=HomeAssistant)
+    hass.data = {DOMAIN: {}}
+    device = _device_entry((DOMAIN, 99999999999))
+    assert (
+        await async_remove_config_entry_device(hass, _config_entry(), device) is False
+    )
+
+    # Also when DOMAIN itself is absent from hass.data.
+    hass.data = {}
+    assert (
+        await async_remove_config_entry_device(hass, _config_entry(), device) is False
+    )
+
+
+async def test_remove_handles_id_coercion() -> None:
+    """Identifier comparison is exact: a string id does not match an int id.
+
+    The integration registers integer ids, so a device entry holding the
+    string form is treated as an orphan (removable) rather than silently
+    matching a live device.
+    """
+    hass = _hass_with_entry()
+    device = _device_entry((DOMAIN, str(CAR_ID)))
+    assert await async_remove_config_entry_device(hass, _config_entry(), device) is True
+
+
+async def test_remove_protects_device_merged_with_foreign_domain() -> None:
+    """A device with our live id plus a foreign-domain id stays protected.
+
+    Device entries can carry identifiers from multiple integrations. As long
+    as one of our live identifiers is present, the device must not be removed.
+    """
+    hass = _hass_with_entry()
+    device = _device_entry((DOMAIN, CAR_ID), ("other_domain", "abc123"))
+    assert (
+        await async_remove_config_entry_device(hass, _config_entry(), device) is False
+    )
+
+
+async def test_remove_orphan_with_only_foreign_domain() -> None:
+    """A device carrying only foreign-domain identifiers is removable."""
+    hass = _hass_with_entry()
+    device = _device_entry(("other_domain", "abc123"))
+    assert await async_remove_config_entry_device(hass, _config_entry(), device) is True
+
+
+@pytest.mark.parametrize("platform", ["binary_sensor"])
+async def test_remove_with_real_loaded_entry(
+    hass: HomeAssistant, platform: str
+) -> None:
+    """Integration test using the real setup fixture and device registry.
+
+    Verifies the live car and energy-site devices created by setup are
+    protected, while an orphaned device under the same entry is removable.
+    """
+    mock_entry, _ = await setup_platform(hass, platform)
+
+    device_registry = dr.async_get(hass)
+
+    # The car must be registered and protected.
+    car_device = device_registry.async_get_device(identifiers={(DOMAIN, CAR_ID)})
+    assert car_device is not None
+    assert await async_remove_config_entry_device(hass, mock_entry, car_device) is False
+
+    # Every device the platform actually registered for this entry is live and
+    # must be protected. Which energy sites register depends on the platform
+    # (e.g. binary_sensor only creates entities for battery sites), so enumerate
+    # the registry rather than assuming a fixed set.
+    entry_devices = dr.async_entries_for_config_entry(
+        device_registry, mock_entry.entry_id
+    )
+    assert entry_devices
+    for device in entry_devices:
+        assert await async_remove_config_entry_device(hass, mock_entry, device) is False
+
+    # A stale device under the same entry (e.g. a car removed from the
+    # account) is no longer provided and must be removable.
+    orphan = device_registry.async_get_or_create(
+        config_entry_id=mock_entry.entry_id,
+        identifiers={(DOMAIN, 99999999999)},
+    )
+    assert await async_remove_config_entry_device(hass, mock_entry, orphan) is True
+
+
+def test_config_entry_title_is_username() -> None:
+    """Sanity check that the shared fixture username constant is wired."""
+    assert TEST_USERNAME == "test-username"

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -134,6 +134,11 @@ async def test_car_cooling_seat_select(hass: HomeAssistant) -> None:
     # Test cars with cooling/heated seats
     del car_mock_data.VEHICLE_DATA["vehicle_config"]["has_seat_cooling"]
     car_mock_data.VEHICLE_DATA["vehicle_config"]["has_seat_cooling"] = True
+    # The "Off" assertion below relies on the seat being in auto mode so that
+    # turning off issues a heater request. Set it explicitly rather than
+    # inheriting the leaked global state from test_car_heated_seat_select, which
+    # is not guaranteed to run first under pytest-xdist (-n auto).
+    car_mock_data.VEHICLE_DATA["climate_state"]["auto_seat_climate_left"] = True
 
     with patch(
         "teslajsonpy.car.TeslaCar.remote_seat_heater_request"

--- a/tests/test_teslamate.py
+++ b/tests/test_teslamate.py
@@ -1,0 +1,28 @@
+"""Tests for TeslaMate MQTT support."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.tesla_custom.teslamate import TeslaMate
+
+from .mock_data import car as car_mock_data
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_get_car_from_id_skips_stale_vin_mapping() -> None:
+    """Test stale VIN mappings do not block active TeslaMate car mappings."""
+    active_car = SimpleNamespace(vin=car_mock_data.VIN)
+    teslamate = object.__new__(TeslaMate)
+    teslamate.cars = {car_mock_data.VIN: active_car}
+    teslamate._data = {
+        "car_map": {
+            "stale-vin": "1",
+            car_mock_data.VIN: "1",
+        }
+    }
+    teslamate.async_load = AsyncMock()
+
+    assert await teslamate.get_car_from_id("1") is active_car


### PR DESCRIPTION
## Release 2026-06-07

Promotes `dev` → `main` to cut a new release. Merging this PR (as a **merge commit**, not squash) triggers `semantic_release.yml`, which computes the version from the conventional commits below, updates the changelog, tags the release, builds and uploads `tesla_custom.zip`, and pushes the bump back to `dev`.

### Changes since 3.26.0

- fix: restore `async_remove_config_entry_device` — re-enables deleting stale `tesla_custom` devices while protecting live cars/energy sites (#1192)
- fix: ignore stale TeslaMate VIN mappings (#1187)
- test: make cooling seat select test independent of execution order (#1193)
- build: pre-commit autoupdate (#1167)

### Expected version

Two `fix:` commits → patch bump: **3.26.0 → 3.26.1** (semantic-release determines the final version).

> ⚠️ Merge with a **merge commit** (not squash) so semantic-release sees the `fix:` commits — a squashed "chore: release" would produce no version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added device removal protection to prevent accidental deletion of active Tesla vehicles and solar sites.

* **Bug Fixes**
  * Improved car lookup reliability to handle stale mappings.

* **Tests**
  * Enhanced test coverage for device management and climate controls.

* **Chores**
  * Updated development tool versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->