### PR TITLE
ci: add reaction reminder for car/powerwall issues

### DIFF
--- a/.github/workflows/issue-reaction-reminder.yml
+++ b/.github/workflows/issue-reaction-reminder.yml
@@ -1,0 +1,52 @@
+name: Issue reaction reminder
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  issues: write
+
+jobs:
+  reminder:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Post reminder comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const issue = context.payload.issue;
+
+            const hasRelevantLabel = issue.labels.some(label =>
+              label.name === "car" || label.name === "powerwall"
+            );
+
+            if (!hasRelevantLabel) return;
+
+            const reminderText =
+            const reminderText =
+              "If you’re affected by this issue or see an existing comment that applies to you, please use 👍 reactions instead of commenting \"same here\". " +
+              "Only add a comment if you have new information that can help investigate the issue. " +
+              "This helps keep the thread clean and easier to track.";
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number
+            });
+
+            const alreadyPosted = comments.some(c =>
+              c.body?.includes("use 👍 reactions") &&
+              c.body?.includes("same here")
+            );
+
+            if (alreadyPosted) return;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: reminderText
+            });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,4 +74,3 @@ asyncio_mode = "auto"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
-


### PR DESCRIPTION
Adds an automated comment on new issues labeled "car" or "powerwall" reminding users to use 👍 reactions instead of posting duplicate comments.

Of course to reduce noise and help maintain cleaner issue discussions.

Warning : I did not test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that posts a reminder on newly opened issues with specific labels, encouraging use of the 👍 reaction instead of reposting "same here" to reduce duplicate comments and improve signal-to-noise.
  * Updated project build configuration to modernize packaging requirements and declare Poetry Core as the build backend for more consistent builds and tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->