### PR TITLE
fix: Use TLS v1.3 to auth

### DIFF
--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -51,7 +51,7 @@ from .const import (
 )
 from .services import async_setup_services, async_unload_services
 from .teslamate import TeslaMate
-from .util import SSL_CONTEXT
+from .util import TESLA_SSL_CONTEXT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -145,10 +145,10 @@ async def async_setup_entry(hass, config_entry):
     if api_proxy_cert := config.get(CONF_API_PROXY_CERT):
         try:
             await hass.async_add_executor_job(
-                SSL_CONTEXT.load_verify_locations, api_proxy_cert
+                TESLA_SSL_CONTEXT.load_verify_locations, api_proxy_cert
             )
             if _LOGGER.isEnabledFor(logging.DEBUG):
-                _LOGGER.debug("Trusting CA: %s", SSL_CONTEXT.get_ca_certs()[-1])
+                _LOGGER.debug("Trusting CA: %s", TESLA_SSL_CONTEXT.get_ca_certs()[-1])
         except (FileNotFoundError, ssl.SSLError):
             _LOGGER.warning(
                 "Unable to load custom SSL certificate from %s",
@@ -156,7 +156,7 @@ async def async_setup_entry(hass, config_entry):
             )
 
     async_client = httpx.AsyncClient(
-        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=SSL_CONTEXT
+        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=TESLA_SSL_CONTEXT
     )
     email = config_entry.title
 

--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -156,7 +156,10 @@ async def async_setup_entry(hass, config_entry):
             )
 
     async_client = httpx.AsyncClient(
-        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=TESLA_SSL_CONTEXT
+        headers={USER_AGENT: SERVER_SOFTWARE},
+        timeout=60,
+        verify=TESLA_SSL_CONTEXT,
+        http2=True,
     )
     email = config_entry.title
 

--- a/custom_components/tesla_custom/config_flow.py
+++ b/custom_components/tesla_custom/config_flow.py
@@ -42,7 +42,7 @@ from .const import (
     DOMAIN,
     MIN_SCAN_INTERVAL,
 )
-from .util import SSL_CONTEXT
+from .util import TESLA_SSL_CONTEXT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -249,7 +249,7 @@ async def validate_input(hass: core.HomeAssistant, data) -> dict:
 
     config = {}
     async_client = httpx.AsyncClient(
-        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=SSL_CONTEXT
+        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=TESLA_SSL_CONTEXT
     )
 
     try:

--- a/custom_components/tesla_custom/config_flow.py
+++ b/custom_components/tesla_custom/config_flow.py
@@ -249,7 +249,10 @@ async def validate_input(hass: core.HomeAssistant, data) -> dict:
 
     config = {}
     async_client = httpx.AsyncClient(
-        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=TESLA_SSL_CONTEXT
+        headers={USER_AGENT: SERVER_SOFTWARE},
+        timeout=60,
+        verify=TESLA_SSL_CONTEXT,
+        http2=True,
     )
 
     try:

--- a/custom_components/tesla_custom/manifest.json
+++ b/custom_components/tesla_custom/manifest.json
@@ -24,6 +24,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/alandtse/tesla/issues",
   "loggers": ["teslajsonpy"],
-  "requirements": ["teslajsonpy==3.13.2"],
+  "requirements": ["teslajsonpy==3.13.2", "h2>=3,<5"],
   "version": "3.26.1"
 }

--- a/custom_components/tesla_custom/util.py
+++ b/custom_components/tesla_custom/util.py
@@ -2,6 +2,8 @@
 
 import ssl
 
+import httpx
+
 try:
     # Home Assistant 2023.4.x+
     from homeassistant.util.ssl import get_default_context
@@ -13,5 +15,6 @@ except ImportError:
     SSL_CONTEXT = client_context()
 
 
-SSL_CONTEXT.minimum_version = ssl.TLSVersion.TLSv1_3
-SSL_CONTEXT.maximum_version = ssl.TLSVersion.TLSv1_3
+TESLA_SSL_CONTEXT = httpx.create_ssl_context()
+TESLA_SSL_CONTEXT.minimum_version = ssl.TLSVersion.TLSv1_3
+TESLA_SSL_CONTEXT.maximum_version = ssl.TLSVersion.TLSv1_3

--- a/custom_components/tesla_custom/util.py
+++ b/custom_components/tesla_custom/util.py
@@ -1,5 +1,7 @@
 """Utilities for tesla."""
 
+import ssl
+
 try:
     # Home Assistant 2023.4.x+
     from homeassistant.util.ssl import get_default_context
@@ -9,3 +11,7 @@ except ImportError:
     from homeassistant.util.ssl import client_context
 
     SSL_CONTEXT = client_context()
+
+
+SSL_CONTEXT.minimum_version = ssl.TLSVersion.TLSv1_3
+SSL_CONTEXT.maximum_version = ssl.TLSVersion.TLSv1_3

--- a/poetry.lock
+++ b/poetry.lock
@@ -1870,6 +1870,22 @@ files = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+description = "Pure-Python HTTP/2 protocol implementation"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"},
+    {file = "h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1"},
+]
+
+[package.dependencies]
+hpack = ">=4.1,<5"
+hyperframe = ">=6.1,<7"
+
+[[package]]
 name = "habluetooth"
 version = "5.7.0"
 description = "High availability Bluetooth"
@@ -2052,6 +2068,18 @@ yarl = "1.20.1"
 zeroconf = "0.147.2"
 
 [[package]]
+name = "hpack"
+version = "4.1.0"
+description = "Pure-Python HPACK header encoding"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"},
+    {file = "hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"},
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 description = "A minimal low-level HTTP client."
@@ -2097,6 +2125,18 @@ cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
 zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+description = "Pure-Python HTTP/2 framing"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"},
+    {file = "hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"},
+]
 
 [[package]]
 name = "identify"
@@ -5777,4 +5817,4 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13.2"
-content-hash = "895cf8762251b5fc348fc8d626a63b0438454daaf9ab37e16a8e1f3b7dbf39a7"
+content-hash = "311bafffa920a2d81e325121dd4e9ed32f1c068aa20ef01324b8dd323a519a62"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ package-mode = false
 python = "^3.13.2"
 teslajsonpy = "3.13.2"
 async-timeout = ">=4.0.0"
+h2 = ">=3,<5"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,4 +74,3 @@ asyncio_mode = "auto"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
-


### PR DESCRIPTION
Fixes #1198 , bumped TLS to v1.3 like in https://github.com/teslamate-org/teslamate/pull/5390

Had to use a separate `TESLA_SSL_CONTEXT` to ensure it doesn't conflict with other projects.

Tested working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tesla API proxy TLS certificate handling by using a dedicated TLS 1.3–only verification context.
  * Applied the same TLS verification update to the configuration credential validation.
* **Chores**
  * Added an `h2` runtime dependency and updated build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->