### PR TITLE
fix: cap the Tesla httpx client to TLS 1.2

### DIFF
--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -51,7 +51,7 @@ from .const import (
 )
 from .services import async_setup_services, async_unload_services
 from .teslamate import TeslaMate
-from .util import SSL_CONTEXT
+from .util import TESLA_SSL_CONTEXT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -145,10 +145,10 @@ async def async_setup_entry(hass, config_entry):
     if api_proxy_cert := config.get(CONF_API_PROXY_CERT):
         try:
             await hass.async_add_executor_job(
-                SSL_CONTEXT.load_verify_locations, api_proxy_cert
+                TESLA_SSL_CONTEXT.load_verify_locations, api_proxy_cert
             )
             if _LOGGER.isEnabledFor(logging.DEBUG):
-                _LOGGER.debug("Trusting CA: %s", SSL_CONTEXT.get_ca_certs()[-1])
+                _LOGGER.debug("Trusting CA: %s", TESLA_SSL_CONTEXT.get_ca_certs()[-1])
         except (FileNotFoundError, ssl.SSLError):
             _LOGGER.warning(
                 "Unable to load custom SSL certificate from %s",
@@ -156,7 +156,7 @@ async def async_setup_entry(hass, config_entry):
             )
 
     async_client = httpx.AsyncClient(
-        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=SSL_CONTEXT
+        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=TESLA_SSL_CONTEXT
     )
     email = config_entry.title
 

--- a/custom_components/tesla_custom/config_flow.py
+++ b/custom_components/tesla_custom/config_flow.py
@@ -42,7 +42,7 @@ from .const import (
     DOMAIN,
     MIN_SCAN_INTERVAL,
 )
-from .util import SSL_CONTEXT
+from .util import TESLA_SSL_CONTEXT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -249,7 +249,7 @@ async def validate_input(hass: core.HomeAssistant, data) -> dict:
 
     config = {}
     async_client = httpx.AsyncClient(
-        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=SSL_CONTEXT
+        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=TESLA_SSL_CONTEXT
     )
 
     try:

--- a/custom_components/tesla_custom/util.py
+++ b/custom_components/tesla_custom/util.py
@@ -1,5 +1,9 @@
 """Utilities for tesla."""
 
+import ssl
+
+import httpx
+
 try:
     # Home Assistant 2023.4.x+
     from homeassistant.util.ssl import get_default_context
@@ -9,3 +13,7 @@ except ImportError:
     from homeassistant.util.ssl import client_context
 
     SSL_CONTEXT = client_context()
+
+
+TESLA_SSL_CONTEXT = httpx.create_ssl_context()
+TESLA_SSL_CONTEXT.maximum_version = ssl.TLSVersion.TLSv1_2


### PR DESCRIPTION
This fixes the Owner API 403 that took the integration down. I use the Owner API, not Fleet API, so everything below is against Owner API.

## What was broken

3.26.1 is not actually broken against Owner API. If you hand the running integration a fresh, valid token it works fine. I manually placed a known good access token and refresh token into a stock 3.26.1 container and the integration ran, full data, zero code changes.

The break is at token refresh. When the integration mints a new token through its own httpx client, Owner API rejects that token with a 403 on the data calls. The refresh call to auth.tesla.com itself returns 200, minting always works, so it is the minted token that gets refused downstream.

Root cause: Tesla is now fingerprinting the TLS handshake used to mint the token. httpx's default TLS 1.3 handshake produces a token Owner API rejects. You can see it in the token itself. A good token and a rejected one are identical except for the `x-enc` claim, an encrypted value that differs depending on what minted the token. So the 403 is not the API dying and not the token being invalid, it is Tesla refusing the client that minted it.

## How I troubleshooted

- Confirmed Owner API is up. The iOS token app gets 200 on `/users/me` and `/vehicles`, so teh API is fine.
- Ruled out the obvious. Source IP (my phone and my Mac are the same egress), User-Agent (tried none, a browser UA, a Tesla app UA), and token validity all made no difference, still 403.
- Fired the same call from one machine across different TLS stacks: curl/LibreSSL, Python urllib/OpenSSL, httpx, Swift on Apple, Elixir on Erlang. The call client was not the gate.
- Found the real split is the mint, not the call. A token minted with urllib (OpenSSL) is accepted, a token minted with curl (LibreSSL) is rejected, and the app's own token works from any client including plain curl. So whatever decides the 403 is baked into the token at mint time.
- Confirmed the app's refresh token is byte for byte the same as mine, so it is not the credentials, it is how the token is minted.
- Isolated the mint down to the TLS handshake. httpx over TLS 1.3 mints a rejected token, httpx capped to TLS 1.2 mints an accepted one. urllib over TLS 1.3 is accepted, so it is httpx's specific TLS 1.3 fingerprint that Tesla rejects, not TLS 1.3 in general.

## What works

Cap the Tesla httpx client to TLS 1.2. I added a dedicated `TESLA_SSL_CONTEXT` (`maximum_version = TLSv1_2`) and routed both AsyncClients (`__init__.py` and `config_flow.py`) through it instead of the shared default context. That gives httpx a handshake Tesla accepts, so the minted token is good. The data pipeline is perfectly happy on TLS 1.2.

To be clear, this is the opposite of pinning TLS 1.3. Pinning 1.3 is exactly the handshake that gets rejected.

## How I have proven it

On my Mac, isolating the mint. httpx capped to TLS 1.2 minted a good token, 200 with full data (vehicle and Powerwall), 3 out of 3 runs. httpx on its default TLS 1.3 minted a rejected token, 403 every time, as the control.

On the live box (HAOS, HA 2026.5.1, teslajsonpy 3.13.2):

- To complete the cycle I minted a fresh refresh token from iOS: Auth App for Tesla, minted a matching access token from it on my Mac, verified that pair returned real data, and seeded it into the box. The integration ran on it with no code changes.
- Deployed the patch, forced the stored token to expire, restarted. The integration refreshed through its own path and minted a working token. The stored expiration advanced to a fresh token and the data calls returned 200 with my vehicle and Powerwall.
- Forced a second expiry to prove it keeps working past one cycle. It refreshed again on its own, using the rotated refresh token, and minted another good token. Debug logs show `success: True` and 200 responses, no 401 or 403 anywhere.
- Read path: entities populate and update. Write path: I switched the car in and out of valet mode from HA and verifed it on the car, and Powerwall commands work too, both over the patched client.

Caveat, these are my limits in testing you may want to verify before accepting

- Owner API only. I do not use Fleet API.
- One environment so far (HAOS amd64, HA 2026.5.1, teslajsonpy 3.13.2).
- This is a workaround for Tesla's current mint handshake fingerprinting. It works now. Tesla could shift it, so the maintainer may want a different long term approach. This gets the integration running again against Owner API today.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved secure connection reliability for the Tesla integration by updating the TLS/CA verification behavior used during setup and configuration checks.

* **Chores**
  * Added and applied a dedicated TLS context for the HTTP client, including restricting TLS to version 1.2 for safer, more consistent handshakes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->