### PR TITLE
fix: multi-account certificate isolation

### DIFF
--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -51,7 +51,7 @@ from .const import (
 )
 from .services import async_setup_services, async_unload_services
 from .teslamate import TeslaMate
-from .util import TESLA_SSL_CONTEXT
+from .util import create_tesla_ssl_context
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -142,13 +142,15 @@ async def async_setup_entry(hass, config_entry):
     # Because users can have multiple accounts, we always
     # create a new session so they have separate cookies
 
+    tesla_ssl_context = create_tesla_ssl_context()
+
     if api_proxy_cert := config.get(CONF_API_PROXY_CERT):
         try:
             await hass.async_add_executor_job(
-                TESLA_SSL_CONTEXT.load_verify_locations, api_proxy_cert
+                tesla_ssl_context.load_verify_locations, api_proxy_cert
             )
             if _LOGGER.isEnabledFor(logging.DEBUG):
-                _LOGGER.debug("Trusting CA: %s", TESLA_SSL_CONTEXT.get_ca_certs()[-1])
+                _LOGGER.debug("Trusting CA: %s", tesla_ssl_context.get_ca_certs()[-1])
         except (FileNotFoundError, ssl.SSLError):
             _LOGGER.warning(
                 "Unable to load custom SSL certificate from %s",
@@ -156,7 +158,7 @@ async def async_setup_entry(hass, config_entry):
             )
 
     async_client = httpx.AsyncClient(
-        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=TESLA_SSL_CONTEXT
+        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=tesla_ssl_context
     )
     email = config_entry.title
 

--- a/custom_components/tesla_custom/config_flow.py
+++ b/custom_components/tesla_custom/config_flow.py
@@ -42,7 +42,7 @@ from .const import (
     DOMAIN,
     MIN_SCAN_INTERVAL,
 )
-from .util import TESLA_SSL_CONTEXT
+from .util import create_tesla_ssl_context
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -249,7 +249,7 @@ async def validate_input(hass: core.HomeAssistant, data) -> dict:
 
     config = {}
     async_client = httpx.AsyncClient(
-        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=TESLA_SSL_CONTEXT
+        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=create_tesla_ssl_context()
     )
 
     try:

--- a/custom_components/tesla_custom/config_flow.py
+++ b/custom_components/tesla_custom/config_flow.py
@@ -3,6 +3,7 @@
 from http import HTTPStatus
 import logging
 import os
+import ssl
 
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import (
@@ -16,7 +17,6 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.httpx_client import SERVER_SOFTWARE, USER_AGENT
-import ssl
 import httpx
 from teslajsonpy import Controller as TeslaAPI, TeslaException
 from teslajsonpy.const import AUTH_DOMAIN

--- a/custom_components/tesla_custom/config_flow.py
+++ b/custom_components/tesla_custom/config_flow.py
@@ -253,7 +253,9 @@ async def validate_input(hass: core.HomeAssistant, data) -> dict:
 
     if api_proxy_cert := data.get(CONF_API_PROXY_CERT):
         try:
-            tesla_ssl_context.load_verify_locations(api_proxy_cert)
+            await hass.async_add_executor_job(
+                tesla_ssl_context.load_verify_locations, api_proxy_cert
+            )
         except (FileNotFoundError, ssl.SSLError):
             _LOGGER.warning(
                 "Unable to load custom SSL certificate from %s",

--- a/custom_components/tesla_custom/config_flow.py
+++ b/custom_components/tesla_custom/config_flow.py
@@ -249,7 +249,9 @@ async def validate_input(hass: core.HomeAssistant, data) -> dict:
 
     config = {}
     async_client = httpx.AsyncClient(
-        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=create_tesla_ssl_context()
+        headers={USER_AGENT: SERVER_SOFTWARE},
+        timeout=60,
+        verify=create_tesla_ssl_context(),
     )
 
     try:

--- a/custom_components/tesla_custom/config_flow.py
+++ b/custom_components/tesla_custom/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.httpx_client import SERVER_SOFTWARE, USER_AGENT
+import ssl
 import httpx
 from teslajsonpy import Controller as TeslaAPI, TeslaException
 from teslajsonpy.const import AUTH_DOMAIN
@@ -248,10 +249,19 @@ async def validate_input(hass: core.HomeAssistant, data) -> dict:
     """
 
     config = {}
+    tesla_ssl_context = create_tesla_ssl_context()
+
+    if api_proxy_cert := data.get(CONF_API_PROXY_CERT):
+        try:
+            tesla_ssl_context.load_verify_locations(api_proxy_cert)
+        except (FileNotFoundError, ssl.SSLError):
+            _LOGGER.warning(
+                "Unable to load custom SSL certificate from %s",
+                api_proxy_cert,
+            )
+
     async_client = httpx.AsyncClient(
-        headers={USER_AGENT: SERVER_SOFTWARE},
-        timeout=60,
-        verify=create_tesla_ssl_context(),
+        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=tesla_ssl_context
     )
 
     try:

--- a/custom_components/tesla_custom/util.py
+++ b/custom_components/tesla_custom/util.py
@@ -15,5 +15,14 @@ except ImportError:
     SSL_CONTEXT = client_context()
 
 
-TESLA_SSL_CONTEXT = httpx.create_ssl_context()
-TESLA_SSL_CONTEXT.maximum_version = ssl.TLSVersion.TLSv1_2
+def create_tesla_ssl_context() -> httpx.AsyncHTTPTransport:
+    """Return a fresh SSL context capped at TLS 1.2 for each caller.
+
+    A module-level shared context would be mutated by every async_setup_entry
+    call, causing the last loaded CA certificate to overwrite all earlier
+    entries. Using a factory ensures each account gets its own isolated
+    context object.
+    """
+    ctx = httpx.create_ssl_context()
+    ctx.maximum_version = ssl.TLSVersion.TLSv1_2
+    return ctx

--- a/custom_components/tesla_custom/util.py
+++ b/custom_components/tesla_custom/util.py
@@ -15,7 +15,7 @@ except ImportError:
     SSL_CONTEXT = client_context()
 
 
-def create_tesla_ssl_context() -> httpx.AsyncHTTPTransport:
+def create_tesla_ssl_context() -> ssl.SSLContext:
     """Return a fresh SSL context capped at TLS 1.2 for each caller.
 
     A module-level shared context would be mutated by every async_setup_entry


### PR DESCRIPTION
## Summary

Fixes #1203

## Root Cause

`TESLA_SSL_CONTEXT` was created once at module import time as a shared mutable object. Each `async_setup_entry` call mutated the same context, causing the last loaded CA certificate to overwrite all earlier entries in multi-account / multi-instance configurations.

## Changes

- **`util.py`**: Replaced module-level `TESLA_SSL_CONTEXT` assignment with a `create_tesla_ssl_context()` factory function that returns a fresh `httpx` SSL context (capped at TLS 1.2) on every call
- **`__init__.py`**: Updated `async_setup_entry` to call `create_tesla_ssl_context()` locally so each account gets its own isolated context instance
- **`config_flow.py`**: Updated `validate_input` to use `create_tesla_ssl_context()` for the same isolation guarantee

## Testing

- Single account setup: no behavior change
- Multi-account setup: each account now gets its own SSL context — CA certificates no longer bleed across accounts

## Impact

- No breaking changes
- Only affects users running multiple Tesla accounts simultaneously

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Tesla API SSL/TLS handling by using a fresh verification context for each connection, avoiding cross-setup conflicts and enforcing TLS 1.2.
* **New Features**
  * Added/strengthened support for loading a user-supplied custom CA certificate for the Tesla API connection.
  * When the certificate file is missing or invalid, the integration now surfaces clear warnings in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->