### PR TITLE
fix: multi-account certificate isolation (#1205)

### DIFF
--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -51,7 +51,7 @@ from .const import (
 )
 from .services import async_setup_services, async_unload_services
 from .teslamate import TeslaMate
-from .util import TESLA_SSL_CONTEXT
+from .util import create_tesla_ssl_context
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -142,13 +142,15 @@ async def async_setup_entry(hass, config_entry):
     # Because users can have multiple accounts, we always
     # create a new session so they have separate cookies
 
+    tesla_ssl_context = create_tesla_ssl_context()
+
     if api_proxy_cert := config.get(CONF_API_PROXY_CERT):
         try:
             await hass.async_add_executor_job(
-                TESLA_SSL_CONTEXT.load_verify_locations, api_proxy_cert
+                tesla_ssl_context.load_verify_locations, api_proxy_cert
             )
             if _LOGGER.isEnabledFor(logging.DEBUG):
-                _LOGGER.debug("Trusting CA: %s", TESLA_SSL_CONTEXT.get_ca_certs()[-1])
+                _LOGGER.debug("Trusting CA: %s", tesla_ssl_context.get_ca_certs()[-1])
         except (FileNotFoundError, ssl.SSLError):
             _LOGGER.warning(
                 "Unable to load custom SSL certificate from %s",
@@ -156,7 +158,7 @@ async def async_setup_entry(hass, config_entry):
             )
 
     async_client = httpx.AsyncClient(
-        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=TESLA_SSL_CONTEXT
+        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=tesla_ssl_context
     )
     email = config_entry.title
 

--- a/custom_components/tesla_custom/config_flow.py
+++ b/custom_components/tesla_custom/config_flow.py
@@ -3,6 +3,7 @@
 from http import HTTPStatus
 import logging
 import os
+import ssl
 
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import (
@@ -42,7 +43,7 @@ from .const import (
     DOMAIN,
     MIN_SCAN_INTERVAL,
 )
-from .util import TESLA_SSL_CONTEXT
+from .util import create_tesla_ssl_context
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -248,8 +249,21 @@ async def validate_input(hass: core.HomeAssistant, data) -> dict:
     """
 
     config = {}
+    tesla_ssl_context = create_tesla_ssl_context()
+
+    if api_proxy_cert := data.get(CONF_API_PROXY_CERT):
+        try:
+            await hass.async_add_executor_job(
+                tesla_ssl_context.load_verify_locations, api_proxy_cert
+            )
+        except (FileNotFoundError, ssl.SSLError):
+            _LOGGER.warning(
+                "Unable to load custom SSL certificate from %s",
+                api_proxy_cert,
+            )
+
     async_client = httpx.AsyncClient(
-        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=TESLA_SSL_CONTEXT
+        headers={USER_AGENT: SERVER_SOFTWARE}, timeout=60, verify=tesla_ssl_context
     )
 
     try:

--- a/custom_components/tesla_custom/const.py
+++ b/custom_components/tesla_custom/const.py
@@ -1,6 +1,6 @@
 """Const file for Tesla cars."""
 
-VERSION = "3.26.2"
+VERSION = "3.26.3"
 CONF_EXPIRATION = "expiration"
 CONF_INCLUDE_VEHICLES = "include_vehicles"
 CONF_INCLUDE_ENERGYSITES = "include_energysites"

--- a/custom_components/tesla_custom/manifest.json
+++ b/custom_components/tesla_custom/manifest.json
@@ -25,5 +25,5 @@
   "issue_tracker": "https://github.com/alandtse/tesla/issues",
   "loggers": ["teslajsonpy"],
   "requirements": ["teslajsonpy==3.13.2"],
-  "version": "3.26.2"
+  "version": "3.26.3"
 }

--- a/custom_components/tesla_custom/util.py
+++ b/custom_components/tesla_custom/util.py
@@ -15,5 +15,14 @@ except ImportError:
     SSL_CONTEXT = client_context()
 
 
-TESLA_SSL_CONTEXT = httpx.create_ssl_context()
-TESLA_SSL_CONTEXT.maximum_version = ssl.TLSVersion.TLSv1_2
+def create_tesla_ssl_context() -> ssl.SSLContext:
+    """Return a fresh SSL context capped at TLS 1.2 for each caller.
+
+    A module-level shared context would be mutated by every async_setup_entry
+    call, causing the last loaded CA certificate to overwrite all earlier
+    entries. Using a factory ensures each account gets its own isolated
+    context object.
+    """
+    ctx = httpx.create_ssl_context()
+    ctx.maximum_version = ssl.TLSVersion.TLSv1_2
+    return ctx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tesla"
-version = "3.26.2"
+version = "3.26.3"
 description = "A fork of the Home Assistant tesla integration using a oauth proxy to login."
 authors = ["Alan D. Tse <alandtse@gmail.com>"]
 license = "Apache-2.0"
@@ -70,6 +70,7 @@ minversion = "7.2"
 addopts = "-ra -q"
 testpaths = ["tests"]
 asyncio_mode = "auto"
+
 
 
 [build-system]


### PR DESCRIPTION
Fixes #1203
Fix return type of create_tesla_ssl_context() from httpx.AsyncHTTPTransport

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SSL/TLS certificate handling by creating isolated contexts for each connection attempt, improving stability and security when proxy certificates are configured.
  * Connection validation updated for consistent certificate loading behavior.
  * Version bumped to 3.26.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->