### PR TITLE
docs: fix text.py strings

### DIFF
--- a/custom_components/tesla_custom/text.py
+++ b/custom_components/tesla_custom/text.py
@@ -1,4 +1,4 @@
-"""Support for Tesla numbers."""
+"""Support for Tesla text entities."""
 
 from homeassistant.components.text import TextEntity, TextMode
 from homeassistant.core import HomeAssistant
@@ -12,7 +12,7 @@ from .teslamate import TeslaMate
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entities):
-    """Set up the Tesla numbers by config_entry."""
+    """Set up the Tesla text entities by config_entry."""
     entry_data = hass.data[DOMAIN][config_entry.entry_id]
     coordinators = entry_data["coordinators"]
     cars = entry_data["cars"]


### PR DESCRIPTION
## Summary

Quality: Inconsistent docstring in text.py module

## Problem

**Severity**: `Low` | **File**: `custom_components/tesla_custom/text.py:L1`

The module docstring says 'Support for Tesla numbers' but the file implements TextEntity for TeslaMate ID. This is a copy-paste error from number.py.

## Solution

Change docstring to 'Support for Tesla text entities.' or similar accurate description.

## Changes

- `custom_components/tesla_custom/text.py` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation strings for accuracy and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->