### PR TITLE
fix: reload when vehicle list changes

### DIFF
--- a/custom_components/tesla_custom/__init__.py
+++ b/custom_components/tesla_custom/__init__.py
@@ -466,6 +466,7 @@ class TeslaDataUpdateCoordinator(DataUpdateCoordinator):
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=config_entry,
             name=DOMAIN,
             update_interval=update_interval,
         )
@@ -503,6 +504,15 @@ class TeslaDataUpdateCoordinator(DataUpdateCoordinator):
                 # another coordinator is already reloading.
                 _LOGGER.debug("Config entry is already being reloaded")
                 return
+            async with self.reload_lock:
+                await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+        except KeyError as err:
+            if not self.update_vehicles:
+                raise
+            if self.reload_lock.locked():
+                _LOGGER.debug("Config entry is already being reloaded")
+                return
+            _LOGGER.info("Reloading config entry after vehicle list changed")
             async with self.reload_lock:
                 await self.hass.config_entries.async_reload(self.config_entry.entry_id)
         except TeslaException as err:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,8 @@
 """Tests for the Tesla integration setup and device removal."""
 
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 from homeassistant.config_entries import ConfigEntry
@@ -9,7 +12,10 @@ import pytest
 from teslajsonpy.car import TeslaCar
 from teslajsonpy.energy import SolarPowerwallSite, SolarSite
 
-from custom_components.tesla_custom import async_remove_config_entry_device
+from custom_components.tesla_custom import (
+    TeslaDataUpdateCoordinator,
+    async_remove_config_entry_device,
+)
 from custom_components.tesla_custom.base import device_identifier
 from custom_components.tesla_custom.const import DOMAIN
 
@@ -215,3 +221,55 @@ async def test_remove_with_real_loaded_entry(
 def test_config_entry_title_is_username() -> None:
     """Sanity check that the shared fixture username constant is wired."""
     assert TEST_USERNAME == "test-username"
+
+
+def _controller_with_update_error(error: Exception):
+    """Return a minimal controller for coordinator update tests."""
+    controller = MagicMock()
+    controller.is_token_refreshed.return_value = False
+    controller.update = AsyncMock(side_effect=error)
+    controller.get_last_update_time.return_value = datetime.now().timestamp()
+    controller.get_last_wake_up_time.return_value = 0
+    controller.is_car_online.return_value = True
+    controller.update_interval = 660
+    return controller
+
+
+async def test_update_vehicles_key_error_reloads_entry(hass: HomeAssistant) -> None:
+    """A new vehicle appearing during product refresh reloads the entry."""
+    config_entry = _config_entry()
+    controller = _controller_with_update_error(KeyError("VIN2"))
+    hass.config_entries.async_reload = AsyncMock()
+    coordinator = TeslaDataUpdateCoordinator(
+        hass,
+        config_entry=config_entry,
+        controller=controller,
+        reload_lock=asyncio.Lock(),
+        update_vehicles=True,
+    )
+
+    assert await coordinator._async_update_data() is None
+
+    controller.update.assert_awaited_once_with(
+        vins=set(), energy_site_ids=set(), update_vehicles=True
+    )
+    hass.config_entries.async_reload.assert_awaited_once_with("test_entry")
+
+
+async def test_vehicle_key_error_is_not_swallowed(hass: HomeAssistant) -> None:
+    """Vehicle-specific KeyErrors still surface as programming/data errors."""
+    config_entry = _config_entry()
+    controller = _controller_with_update_error(KeyError("VIN2"))
+    hass.config_entries.async_reload = AsyncMock()
+    coordinator = TeslaDataUpdateCoordinator(
+        hass,
+        config_entry=config_entry,
+        controller=controller,
+        reload_lock=asyncio.Lock(),
+        vin=car_mock_data.VIN,
+    )
+
+    with pytest.raises(KeyError):
+        await coordinator._async_update_data()
+
+    hass.config_entries.async_reload.assert_not_awaited()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,8 +2,7 @@
 
 import asyncio
 from datetime import datetime
-from unittest.mock import AsyncMock
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant


### PR DESCRIPTION
## Summary

Reload the config entry when the product-list refresh discovers a vehicle that is not yet present in the current controller vehicle cache.

This keeps the update-vehicles coordinator from getting stuck on the transient `KeyError` path seen after a new vehicle is added, while preserving the existing behavior for vehicle-specific `KeyError`s.

Fixes #636.

## Tests

```text
.venv/bin/pytest tests/test_init.py -k 'key_error or update_vehicles' -q
..                                                                       [100%]

.venv/bin/black --check custom_components/tesla_custom/__init__.py tests/test_init.py
All done! 2 files would be left unchanged.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling when vehicle data changes during synchronization, allowing the system to automatically recover without losing connection.

* **Tests**
  * Added test coverage for vehicle list change scenarios during data updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->