### PR TITLE
fix: handle missing vehicle state for locks

### DIFF
--- a/custom_components/tesla_custom/lock.py
+++ b/custom_components/tesla_custom/lock.py
@@ -54,9 +54,9 @@ class TeslaCarDoors(TeslaCarEntity, LockEntity):
     def is_locked(self):
         """Return True if door is locked."""
         vehicle_state = self._car._vehicle_data.get("vehicle_state")
-        if not isinstance(vehicle_state, dict):
+        if not isinstance(vehicle_state, dict) or "locked" not in vehicle_state:
             return None
-        return self._car.is_locked
+        return vehicle_state["locked"]
 
 
 class TeslaCarChargePortLatch(TeslaCarEntity, LockEntity):

--- a/custom_components/tesla_custom/lock.py
+++ b/custom_components/tesla_custom/lock.py
@@ -31,21 +31,31 @@ class TeslaCarDoors(TeslaCarEntity, LockEntity):
 
     type = "doors"
 
+    def _ensure_vehicle_state(self) -> None:
+        """Ensure vehicle_state can be updated after lock commands."""
+        if not isinstance(self._car._vehicle_data.get("vehicle_state"), dict):
+            self._car._vehicle_data["vehicle_state"] = {}
+
     async def async_lock(self, **kwargs):
         """Send lock command."""
         _LOGGER.debug("Locking: %s", self.name)
+        self._ensure_vehicle_state()
         await self._car.lock()
         self.async_write_ha_state()
 
     async def async_unlock(self, **kwargs):
         """Send unlock command."""
         _LOGGER.debug("Unlocking: %s", self.name)
+        self._ensure_vehicle_state()
         await self._car.unlock()
         self.async_write_ha_state()
 
     @property
     def is_locked(self):
         """Return True if door is locked."""
+        vehicle_state = self._car._vehicle_data.get("vehicle_state")
+        if not isinstance(vehicle_state, dict):
+            return None
         return self._car.is_locked
 
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,12 +1,14 @@
 """Tests for the Tesla lock."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 import pytest
+
+from custom_components.tesla_custom.lock import TeslaCarDoors
 
 from .common import setup_platform
 from .mock_data import car as car_mock_data
@@ -75,6 +77,21 @@ async def test_car_door_unlock_without_vehicle_state(
         assert car._vehicle_data["vehicle_state"]["locked"] is False
     finally:
         car._vehicle_data["vehicle_state"] = original_vehicle_state
+
+
+def test_car_door_reports_unknown_without_locked_vehicle_state() -> None:
+    """Tests a missing lock value is exposed as an unknown state."""
+    car = MagicMock()
+    car.vin = car_mock_data.VIN
+    car.display_name = "My Model S"
+    car.car_type = "models"
+    car.car_version = "2026.20"
+    car.id = 1
+    car._vehicle_data = {"vehicle_state": {}}
+
+    entity = TeslaCarDoors(car, MagicMock())
+
+    assert entity.is_locked is None
 
 
 async def test_charge_port_latch(hass: HomeAssistant) -> None:

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,11 +1,12 @@
 """Tests for the Tesla lock."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+import pytest
 
 from .common import setup_platform
 from .mock_data import car as car_mock_data
@@ -41,6 +42,39 @@ async def test_car_door(hass: HomeAssistant) -> None:
             blocking=True,
         )
         mock_unlock.assert_awaited_once()
+
+
+@pytest.mark.parametrize("vehicle_state", [None, pytest.param({}, id="missing")])
+async def test_car_door_unlock_without_vehicle_state(
+    hass: HomeAssistant, vehicle_state: dict | None
+) -> None:
+    """Tests car door unlock handles unavailable vehicle state."""
+    _, mock_controller = await setup_platform(hass, LOCK_DOMAIN)
+    car = mock_controller.return_value.generate_car_objects.return_value[
+        car_mock_data.VIN
+    ]
+    original_vehicle_state = car._vehicle_data.get("vehicle_state")
+
+    try:
+        if vehicle_state is None:
+            car._vehicle_data["vehicle_state"] = None
+        else:
+            car._vehicle_data.pop("vehicle_state")
+        car._send_command = AsyncMock(
+            return_value={"response": {"result": True, "reason": ""}}
+        )
+
+        await hass.services.async_call(
+            LOCK_DOMAIN,
+            SERVICE_UNLOCK,
+            {ATTR_ENTITY_ID: "lock.my_model_s_doors"},
+            blocking=True,
+        )
+
+        car._send_command.assert_awaited_once_with("UNLOCK")
+        assert car._vehicle_data["vehicle_state"]["locked"] is False
+    finally:
+        car._vehicle_data["vehicle_state"] = original_vehicle_state
 
 
 async def test_charge_port_latch(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Fixes #555.

Summary:
- Handle missing or null vehicle state before door lock commands update cached lock state.
- Report unknown door lock state instead of raising when vehicle state is unavailable.

Validation:
- `POETRY_VIRTUALENVS_IN_PROJECT=true uvx poetry -C alandtse-tesla-OSS-3177 run pytest tests/test_lock.py -q`
- `POETRY_VIRTUALENVS_IN_PROJECT=true uvx poetry -C alandtse-tesla-OSS-3177 run black --check custom_components/tesla_custom/lock.py tests/test_lock.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved door lock/unlock reliability by normalizing and validating vehicle state data before sending lock/unlock commands.
* Updated lock status reporting to reflect the `locked` value from vehicle state, returning an “unknown” status when vehicle state data is missing or malformed.
* Added automated test coverage for unlock behavior and unknown lock status when vehicle state information is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->