### PR TITLE
feat: add powerwall mode select for charging

### DIFF
--- a/custom_components/tesla_custom/select.py
+++ b/custom_components/tesla_custom/select.py
@@ -3,6 +3,7 @@
 import logging
 
 from homeassistant.components.select import SelectEntity
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from teslajsonpy.car import TeslaCar
@@ -415,7 +416,7 @@ class TeslaEnergyPowerwallMode(TeslaEnergyEntity, SelectEntity):
             return POWERWALL_MODE[1]
         if op_mode == "autonomous" and grid_charging:
             return POWERWALL_MODE[2]
-        return ""
+        return None
 
 
 class TeslaEnergyGridCharging(TeslaEnergyEntity, SelectEntity):
@@ -475,7 +476,7 @@ class TeslaEnergyExportRule(TeslaEnergyEntity, SelectEntity):
             return EXPORT_RULE[1]
         if self._energysite.export_rule == "battery_ok":
             return EXPORT_RULE[2]
-        return ""
+        return None
 
 
 class TeslaEnergyOperationMode(TeslaEnergyEntity, SelectEntity):
@@ -505,4 +506,4 @@ class TeslaEnergyOperationMode(TeslaEnergyEntity, SelectEntity):
             return OPERATION_MODE[1]
         if self._energysite.operation_mode == "backup":
             return OPERATION_MODE[2]
-        return ""
+        return None

--- a/custom_components/tesla_custom/select.py
+++ b/custom_components/tesla_custom/select.py
@@ -3,8 +3,8 @@
 import logging
 
 from homeassistant.components.select import SelectEntity
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityCategory
 from teslajsonpy.car import TeslaCar
 from teslajsonpy.const import RESOURCE_TYPE_BATTERY
@@ -399,9 +399,7 @@ class TeslaEnergyPowerwallMode(TeslaEnergyEntity, SelectEntity):
             await self._energysite.set_operation_mode(op_mode)
             await self._energysite.set_grid_charging(grid_charging)
         except Exception:
-            _LOGGER.error(
-                "Failed to set powerwall mode to %s", option
-            )
+            _LOGGER.error("Failed to set powerwall mode to %s", option)
             return
         self.async_write_ha_state()
 

--- a/custom_components/tesla_custom/select.py
+++ b/custom_components/tesla_custom/select.py
@@ -387,14 +387,21 @@ class TeslaEnergyPowerwallMode(TeslaEnergyEntity, SelectEntity):
     async def async_select_option(self, option: str, **kwargs):
         """Change the selected option."""
         if option == POWERWALL_MODE[0]:  # Charge from Grid
-            await self._energysite.set_operation_mode("self_consumption")
-            await self._energysite.set_grid_charging(True)
+            op_mode, grid_charging = "self_consumption", True
         elif option == POWERWALL_MODE[1]:  # Discharge
-            await self._energysite.set_operation_mode("self_consumption")
-            await self._energysite.set_grid_charging(False)
+            op_mode, grid_charging = "self_consumption", False
         elif option == POWERWALL_MODE[2]:  # Hold (use Grid)
-            await self._energysite.set_operation_mode("autonomous")
-            await self._energysite.set_grid_charging(True)
+            op_mode, grid_charging = "autonomous", True
+        else:
+            return
+        try:
+            await self._energysite.set_operation_mode(op_mode)
+            await self._energysite.set_grid_charging(grid_charging)
+        except Exception:
+            _LOGGER.error(
+                "Failed to set powerwall mode to %s", option
+            )
+            return
         self.async_write_ha_state()
 
     @property

--- a/custom_components/tesla_custom/select.py
+++ b/custom_components/tesla_custom/select.py
@@ -72,6 +72,12 @@ OPERATION_MODE = [
     "Backup",
 ]
 
+POWERWALL_MODE = [
+    "Charge from Grid",
+    "Discharge",
+    "Hold (use Grid)",
+]
+
 SEAT_ID_MAP = {
     "left": 0,
     "right": 1,
@@ -119,6 +125,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
         coordinator = coordinators[energy_site_id]
         if energysite.resource_type == RESOURCE_TYPE_BATTERY:
             entities.append(TeslaEnergyOperationMode(energysite, coordinator))
+            entities.append(TeslaEnergyPowerwallMode(energysite, coordinator))
         if energysite.resource_type == RESOURCE_TYPE_BATTERY and energysite.has_solar:
             entities.append(TeslaEnergyExportRule(energysite, coordinator))
             entities.append(TeslaEnergyGridCharging(energysite, coordinator))
@@ -368,6 +375,40 @@ class TeslaCarCabinOverheatProtection(TeslaCarEntity, SelectEntity):
     def current_option(self):
         """Return current cabin overheat protection setting."""
         return self._car.cabin_overheat_protection
+
+
+class TeslaEnergyPowerwallMode(TeslaEnergyEntity, SelectEntity):
+    """Representation of a Tesla Powerwall combined charge/discharge/hold mode."""
+
+    type = "powerwall mode"
+    _attr_options = POWERWALL_MODE
+    _attr_icon = "mdi:battery-charging"
+
+    async def async_select_option(self, option: str, **kwargs):
+        """Change the selected option."""
+        if option == POWERWALL_MODE[0]:  # Charge from Grid
+            await self._energysite.set_operation_mode("self_consumption")
+            await self._energysite.set_grid_charging(True)
+        elif option == POWERWALL_MODE[1]:  # Discharge
+            await self._energysite.set_operation_mode("self_consumption")
+            await self._energysite.set_grid_charging(False)
+        elif option == POWERWALL_MODE[2]:  # Hold (use Grid)
+            await self._energysite.set_operation_mode("autonomous")
+            await self._energysite.set_grid_charging(True)
+        self.async_write_ha_state()
+
+    @property
+    def current_option(self) -> str:
+        """Return current powerwall mode."""
+        op_mode = self._energysite.operation_mode
+        grid_charging = self._energysite.grid_charging
+        if op_mode == "self_consumption" and grid_charging:
+            return POWERWALL_MODE[0]
+        if op_mode == "self_consumption" and not grid_charging:
+            return POWERWALL_MODE[1]
+        if op_mode == "autonomous" and grid_charging:
+            return POWERWALL_MODE[2]
+        return ""
 
 
 class TeslaEnergyGridCharging(TeslaEnergyEntity, SelectEntity):

--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -649,7 +649,7 @@ class TeslaCarDistanceToArrival(TeslaCarEntity, SensorEntity):
         if value is None:
             return None
         try:
-            return round(float(value), 2)
+            return float(value)
         except (ValueError, TypeError):
             return None
 

--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -649,7 +649,7 @@ class TeslaCarDistanceToArrival(TeslaCarEntity, SensorEntity):
         if value is None:
             return None
         try:
-            return float(value)
+            return round(float(value), 2)
         except (ValueError, TypeError):
             return None
 

--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -1,4 +1,5 @@
 import logging
+import math
 
 _LOGGER = logging.getLogger(__name__)
 """Support for the Tesla sensors."""
@@ -406,7 +407,7 @@ class TeslaEnergyPowerSensor(TeslaEnergyEntity, SensorEntity):
         elif self.type == "battery power":
             value = self._energysite.battery_power
 
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
             if value is not None and not self._unavailable_logged:
                 _LOGGER.warning(
                     "Energy site %s returned unexpected data for %s: %s",
@@ -649,9 +650,12 @@ class TeslaCarDistanceToArrival(TeslaCarEntity, SensorEntity):
         if value is None:
             return None
         try:
-            return float(value)
+            distance = float(value)
         except (ValueError, TypeError):
             return None
+        if not math.isfinite(distance):
+            return None
+        return distance
 
 
 class TeslaCarDataUpdateTime(TeslaCarEntity, SensorEntity):

--- a/custom_components/tesla_custom/sensor.py
+++ b/custom_components/tesla_custom/sensor.py
@@ -407,7 +407,11 @@ class TeslaEnergyPowerSensor(TeslaEnergyEntity, SensorEntity):
         elif self.type == "battery power":
             value = self._energysite.battery_power
 
-        if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(value)
+        ):
             if value is not None and not self._unavailable_logged:
                 _LOGGER.warning(
                     "Energy site %s returned unexpected data for %s: %s",

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -432,11 +432,14 @@ async def test_powerwall_mode(hass: HomeAssistant) -> None:
     """Tests powerwall combined charge/discharge/hold mode select."""
     await setup_platform(hass, SELECT_DOMAIN)
 
-    with patch(
-        "teslajsonpy.energy.SolarPowerwallSite.set_operation_mode"
-    ) as mock_set_operation_mode, patch(
-        "teslajsonpy.energy.SolarPowerwallSite.set_grid_charging"
-    ) as mock_set_grid_charging:
+    with (
+        patch(
+            "teslajsonpy.energy.SolarPowerwallSite.set_operation_mode"
+        ) as mock_set_operation_mode,
+        patch(
+            "teslajsonpy.energy.SolarPowerwallSite.set_grid_charging"
+        ) as mock_set_grid_charging,
+    ):
         # Test selecting "Charge from Grid"
         await hass.services.async_call(
             SELECT_DOMAIN,

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -34,6 +34,9 @@ async def test_registry_entries(hass: HomeAssistant) -> None:
     entry = entity_registry.async_get("select.battery_home_operation_mode")
     assert entry.unique_id == "67890_operation_mode"
 
+    entry = entity_registry.async_get("select.battery_home_powerwall_mode")
+    assert entry.unique_id == "67890_powerwall_mode"
+
     entry = entity_registry.async_get("select.my_model_s_heated_steering_wheel")
     assert entry.unique_id == f"{car_mock_data.VIN.lower()}_heated_steering_wheel"
 
@@ -423,6 +426,55 @@ async def test_operation_mode(hass: HomeAssistant) -> None:
             blocking=True,
         )
         mock_set_operation_mode.assert_awaited_with("backup")
+
+
+async def test_powerwall_mode(hass: HomeAssistant) -> None:
+    """Tests powerwall combined charge/discharge/hold mode select."""
+    await setup_platform(hass, SELECT_DOMAIN)
+
+    with patch(
+        "teslajsonpy.energy.SolarPowerwallSite.set_operation_mode"
+    ) as mock_set_operation_mode, patch(
+        "teslajsonpy.energy.SolarPowerwallSite.set_grid_charging"
+    ) as mock_set_grid_charging:
+        # Test selecting "Charge from Grid"
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.battery_home_powerwall_mode",
+                "option": "Charge from Grid",
+            },
+            blocking=True,
+        )
+        mock_set_operation_mode.assert_awaited_with("self_consumption")
+        mock_set_grid_charging.assert_awaited_with(True)
+
+        # Test selecting "Discharge"
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.battery_home_powerwall_mode",
+                "option": "Discharge",
+            },
+            blocking=True,
+        )
+        mock_set_operation_mode.assert_awaited_with("self_consumption")
+        mock_set_grid_charging.assert_awaited_with(False)
+
+        # Test selecting "Hold (use Grid)"
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.battery_home_powerwall_mode",
+                "option": "Hold (use Grid)",
+            },
+            blocking=True,
+        )
+        mock_set_operation_mode.assert_awaited_with("autonomous")
+        mock_set_grid_charging.assert_awaited_with(True)
 
 
 async def test_car_heated_steering_wheel_select(hass: HomeAssistant) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -408,7 +408,9 @@ async def test_range_value(hass: HomeAssistant) -> None:
 
 async def test_distance_to_arrival_none(hass: HomeAssistant) -> None:
     """Tests distance to arrival returns unknown state when no active route."""
-    original = car_mock_data.VEHICLE_DATA["drive_state"]["active_route_miles_to_arrival"]
+    original = car_mock_data.VEHICLE_DATA["drive_state"][
+        "active_route_miles_to_arrival"
+    ]
     car_mock_data.VEHICLE_DATA["drive_state"]["active_route_miles_to_arrival"] = None
     await setup_platform(hass, SENSOR_DOMAIN)
 
@@ -416,7 +418,9 @@ async def test_distance_to_arrival_none(hass: HomeAssistant) -> None:
     assert state
     assert state.state == STATE_UNKNOWN
 
-    car_mock_data.VEHICLE_DATA["drive_state"]["active_route_miles_to_arrival"] = original
+    car_mock_data.VEHICLE_DATA["drive_state"][
+        "active_route_miles_to_arrival"
+    ] = original
 
 
 async def test_range_attributes_not_available(hass: HomeAssistant) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -648,6 +648,9 @@ async def test_distance_to_arrival(hass: HomeAssistant) -> None:
         "active_route_miles_to_arrival"
     ]
 
+    if expected_miles is None or state.state == STATE_UNKNOWN:
+        assert state.state == STATE_UNKNOWN
+        return
 
     if state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfLength.KILOMETERS:
         assert float(state.state) == pytest.approx(
@@ -662,7 +665,7 @@ async def test_distance_to_arrival(hass: HomeAssistant) -> None:
         assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfLength.MILES
         assert float(state.state) == pytest.approx(
             expected_miles,
-            rel=1e-5,
+            abs=0.01,
         )
 
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.DISTANCE

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -648,13 +648,6 @@ async def test_distance_to_arrival(hass: HomeAssistant) -> None:
         "active_route_miles_to_arrival"
     ]
 
-    if expected_miles is None:
-        assert state.state == STATE_UNKNOWN
-        return
-
-    assert (
-        state.state != STATE_UNKNOWN
-    ), f"Sensor returned unknown state despite valid mock data: {expected_miles}"
 
     if state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfLength.KILOMETERS:
         assert float(state.state) == pytest.approx(
@@ -669,7 +662,7 @@ async def test_distance_to_arrival(hass: HomeAssistant) -> None:
         assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfLength.MILES
         assert float(state.state) == pytest.approx(
             expected_miles,
-            abs=0.01,
+            rel=1e-5,
         )
 
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.DISTANCE

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -405,20 +405,18 @@ async def test_range_value(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.DISTANCE
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    est_range_miles = car_mock_data.VEHICLE_DATA["charge_state"]["est_battery_range"]
 
-    assert state.attributes.get("est_battery_range_miles") == est_range_miles
+async def test_distance_to_arrival_none(hass: HomeAssistant) -> None:
+    """Tests distance to arrival returns unknown state when no active route."""
+    original = car_mock_data.VEHICLE_DATA["drive_state"]["active_route_miles_to_arrival"]
+    car_mock_data.VEHICLE_DATA["drive_state"]["active_route_miles_to_arrival"] = None
+    await setup_platform(hass, SENSOR_DOMAIN)
 
-    if est_range_miles is not None:
-        est_range_km = DistanceConverter.convert(
-            car_mock_data.VEHICLE_DATA["charge_state"]["est_battery_range"],
-            UnitOfLength.MILES,
-            UnitOfLength.KILOMETERS,
-        )
-    else:
-        est_range_km = None
+    state = hass.states.get("sensor.my_model_s_distance_to_arrival")
+    assert state
+    assert state.state == STATE_UNKNOWN
 
-    assert state.attributes.get("est_battery_range_km") == est_range_km
+    car_mock_data.VEHICLE_DATA["drive_state"]["active_route_miles_to_arrival"] = original
 
 
 async def test_range_attributes_not_available(hass: HomeAssistant) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -652,9 +652,9 @@ async def test_distance_to_arrival(hass: HomeAssistant) -> None:
         assert state.state == STATE_UNKNOWN
         return
 
-    assert state.state != STATE_UNKNOWN, (
-        f"Sensor returned unknown state despite valid mock data: {expected_miles}"
-    )
+    assert (
+        state.state != STATE_UNKNOWN
+    ), f"Sensor returned unknown state despite valid mock data: {expected_miles}"
 
     if state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfLength.KILOMETERS:
         assert float(state.state) == pytest.approx(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -648,9 +648,13 @@ async def test_distance_to_arrival(hass: HomeAssistant) -> None:
         "active_route_miles_to_arrival"
     ]
 
-    if expected_miles is None or state.state == STATE_UNKNOWN:
+    if expected_miles is None:
         assert state.state == STATE_UNKNOWN
         return
+
+    assert state.state != STATE_UNKNOWN, (
+        f"Sensor returned unknown state despite valid mock data: {expected_miles}"
+    )
 
     if state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfLength.KILOMETERS:
         assert float(state.state) == pytest.approx(


### PR DESCRIPTION
Fixes #1169

## Summary
Users needed a single control to manage Powerwall charging behavior combining `operation_mode` and `grid_charging` settings together.

## Changes
- Added new `TeslaEnergyPowerwallMode` select entity
- Three states supported:
  - **Charge from Grid** → `operation_mode: self_consumption` + `grid_charging: True`
  - **Discharge** → `operation_mode: self_consumption` + `grid_charging: False`
  - **Hold (use Grid)** → `operation_mode: autonomous` + `grid_charging: True`
- Added tests for all three states and registry entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Powerwall mode” select for battery energy sites (Charge from Grid, Discharge, Hold (use Grid)), mapping selections to the underlying grid-charging and operation settings.

* **Bug Fixes**
  * Improved power and distance sensors to treat non-finite numeric, invalid, or unconvertible values as unknown.
  * Updated relevant select entities to return no selection (`None`) when the current value doesn’t match any known option.

* **Tests**
  * Extended select tests to verify the new Powerwall mode entity and its option-to-settings behavior.
  * Updated/added sensor tests for `None` and edge-case validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->