### PR TITLE
fix: replace deprecated TrackerEntity alias with direct import

### DIFF
--- a/custom_components/tesla_custom/device_tracker.py
+++ b/custom_components/tesla_custom/device_tracker.py
@@ -2,8 +2,7 @@
 
 import logging
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker import SourceType, TrackerEntity
 from homeassistant.core import HomeAssistant
 
 from .base import TeslaCarEntity


### PR DESCRIPTION
Fixes #1195

## Summary
Replace the deprecated `TrackerEntity` import from `homeassistant.components.device_tracker.config_entry` with a direct import from `homeassistant.components.device_tracker`, which is the correct location as of HA Core 2026.6.

Also consolidates the two separate `device_tracker` imports into a single line.

## Changes
- `custom_components/tesla_custom/device_tracker.py`: update import path for `TrackerEntity`

## Testing
Resolves the deprecation warning seen on HA 2026.6.1 startup:
```
WARNING (ImportExecutor_0) [homeassistant.components.device_tracker.config_entry] The deprecated alias TrackerEntity was used from tesla_custom. It will be removed in HA Core 2027.6.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the device tracking integration to use a more current shared component interface.
  * No user-facing behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->