### PR TITLE
ci: fix reaction workflow reminder bot and add "bug" label

### DIFF
--- a/.github/workflows/issue-reaction-reminder.yml
+++ b/.github/workflows/issue-reaction-reminder.yml
@@ -3,10 +3,14 @@ name: Issue reaction reminder
 on:
   issues:
     types:
-      - opened
+      - labeled
 
 permissions:
   issues: write
+
+concurrency:
+  group: issue-reaction-reminder-${{ github.event.issue.number }}
+  cancel-in-progress: false
 
 jobs:
   reminder:
@@ -18,16 +22,14 @@ jobs:
         with:
           script: |
             const issue = context.payload.issue;
+            const triggeringLabel = context.payload.label?.name;
+            const relevantLabels = ["bug", "car", "powerwall"];
 
-            const hasRelevantLabel = issue.labels.some(label =>
-              label.name === "car" || label.name === "powerwall"
-            );
-
-            if (!hasRelevantLabel) return;
+            if (!relevantLabels.includes(triggeringLabel)) return;
 
             const reminderText =
-            const reminderText =
-              "If you’re affected by this issue or see an existing comment that applies to you, please use 👍 reactions instead of commenting \"same here\". " +
+              "<!-- hidden-issue-reaction-reminder-marker -->\n" +
+              "If you're affected by this issue or see an existing comment that applies to you, please react with 👍 instead of commenting \"same here\". " +
               "Only add a comment if you have new information that can help investigate the issue. " +
               "This helps keep the thread clean and easier to track.";
 
@@ -38,8 +40,7 @@ jobs:
             });
 
             const alreadyPosted = comments.some(c =>
-              c.body?.includes("use 👍 reactions") &&
-              c.body?.includes("same here")
+              c.body?.includes("<!-- hidden-issue-reaction-reminder-marker -->")
             );
 
             if (alreadyPosted) return;


### PR DESCRIPTION
Trying to fix the previous workflow, I ended up asking some AI tool to check and fix a concurrency issue. 

Post a comment on issues labeled "car", "powerwall", or added "bug" label asking folks to use a 👍 reaction instead of "me too" comments.

- Trigger on `issues: labeled` (fires per-label, including labels applied via issue template frontmatter on creation)
- Dedupe using a hidden HTML comment marker rather than matching on the visible reminder text, so wording can be edited freely without breaking the check
- Scope a per-issue concurrency group (cancel-in-progress: false) so concurrent label events on the same issue can't race past the check-then-comment step and post duplicates

## Testing
Somehow my Github account can't run the workflow. While working on this PR, a month ago I open a support ticket. As of today, still no resolution :/

Since the previous merged PR doesn't work at all, I propose we merge this one and hope this time it works as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Issue reminders now run when the supported labels are added, rather than only when issues are opened.
  * Prevented duplicate or conflicting reminder runs for the same issue.
  * Improved detection of existing reminders to avoid posting duplicates.
  * Updated reminder wording and reaction guidance for greater clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->