### PR TITLE
ci: auto-close stale issues

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,36 @@
+name: Close stale issues
+on:
+  schedule:
+    - cron: '30 1 * * *'   # once a day
+  workflow_dispatch: {}    # can trigger manually to test
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          # --- Issues ---
+          days-before-issue-stale: 60
+          days-before-issue-close: 7
+          stale-issue-label: 'stale'
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has had
+            no activity for 60 days. It will be closed in 7 days if no further
+            activity occurs. If this is still relevant, a comment will remove the
+            stale label and keep it open.
+          close-issue-message: >
+            This issue has been automatically closed after 7 days of inactivity
+            since being marked stale. If this is still an issue, feel free to
+            reopen it or open a new one with updated details.
+
+          # --- Pull requests: disabled ---
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+          exempt-issue-labels: 'pinned,security'
+          operations-per-run: 100

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,8 +1,8 @@
 name: Close stale issues
 on:
   schedule:
-    - cron: '30 1 * * *'   # once a day
-  workflow_dispatch: {}    # can trigger manually to test
+    - cron: "30 1 * * *" # once a day
+  workflow_dispatch: {} # can trigger manually to test
 
 permissions:
   issues: write
@@ -17,7 +17,7 @@ jobs:
           # --- Issues ---
           days-before-issue-stale: 60
           days-before-issue-close: 7
-          stale-issue-label: 'stale'
+          stale-issue-label: "stale"
           stale-issue-message: >
             This issue has been automatically marked as stale because it has had
             no activity for 60 days. It will be closed in 7 days if no further
@@ -32,5 +32,5 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
 
-          exempt-issue-labels: 'pinned,security'
+          exempt-issue-labels: "pinned,security"
           operations-per-run: 100


### PR DESCRIPTION
Adds a scheduled workflow (`actions/stale`) to keep the issue tracker from accumulating dead threads indefinitely.

Behavior:
- If an issue has had no activity for 60 days, post a comment marking it stale and warning it will close in 7 days without further activity
- If 7 more days pass with no comment, close it automatically
- Any new comment removes the stale label and resets the clock

Notes:
- Runs daily via `schedule` (`workflow_dispatch` also enabled for manual testing)
- PR staling is explicitly disabled — this only affects issues
- `pull-requests: write` is required otherwise it fails with a 403
- `exempt-issue-labels` is a placeholder for labels that should never auto-close (e.g. pinned/security)

## Testing
Can't test in my account yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to manage inactive issues.
  * Issues inactive for 60 days are marked as stale, and closed 7 days later if inactivity continues.
  * Added exemptions for pinned and security-related issues.
  * Pull requests are excluded from this automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->