### PR TITLE
Update SSL context creation in util.py

### DIFF
--- a/custom_components/tesla_custom/util.py
+++ b/custom_components/tesla_custom/util.py
@@ -2,17 +2,7 @@
 
 import ssl
 
-import httpx
-
-try:
-    # Home Assistant 2023.4.x+
-    from homeassistant.util.ssl import get_default_context
-
-    SSL_CONTEXT = get_default_context()
-except ImportError:
-    from homeassistant.util.ssl import client_context
-
-    SSL_CONTEXT = client_context()
+from homeassistant.util.ssl import get_default_context
 
 
 def create_tesla_ssl_context() -> ssl.SSLContext:
@@ -23,6 +13,8 @@ def create_tesla_ssl_context() -> ssl.SSLContext:
     entries. Using a factory ensures each account gets its own isolated
     context object.
     """
-    ctx = httpx.create_ssl_context()
+    # get_default_context() retourne un nouveau contexte à chaque appel,
+    # ce qui respecte la logique d'isolation voulue par l'intégration.
+    ctx = get_default_context()
     ctx.maximum_version = ssl.TLSVersion.TLSv1_2
     return ctx


### PR DESCRIPTION
Refactor SSL context creation to use get_default_context from Home Assistant.

Resolving Blocking call to httpx.create_ssl_context() in async_setup_entry freezes entire Home Assistant instance


#1234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tesla connection security by using Home Assistant’s default SSL settings.
  * Limited connections to TLS 1.2 for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->